### PR TITLE
Make read S3 requests be asynchronous 

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -643,7 +643,7 @@ class S3Connection(AWSAuthConnection):
 
     def make_request(self, method, bucket='', key='', headers=None, data='',
                      query_args=None, sender=None, override_num_retries=None,
-                     retry_handler=None, async=False):
+                     retry_handler=None, async=True):
         if isinstance(bucket, self.bucket_class):
             bucket = bucket.name
         if isinstance(key, Key):
@@ -663,5 +663,5 @@ class S3Connection(AWSAuthConnection):
             data, host, auth_path, sender,
             override_num_retries=override_num_retries,
             retry_handler=retry_handler,
-            async=False
+            async=async
         )


### PR DESCRIPTION
Not the prettiest code ever but this will make it so that HEAD/GET requests that the monolith uses for reading from S3 will be asynchronous. Writes (PUT) will remain blocking as S3 uses a custom sender for uploading a file.

Tested it two ways, ran the wish FE server with the updated code below and saw GET/HEAD requests enter the asynchronous cl_mexe path with no issues.

With the same updated boto code, created a script that would upload a file to a bucket and saw the upload succeed and it did not try to enter the asynchronous cl_mexe code path. 