### PR TITLE
Only set content-type header to empty string if it doesn't already exist

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1000,7 +1000,7 @@ class AWSAuthConnection(object):
         # By defaulting the header to empty string, we prevent curl
         # from setting by default. Regular boto http library doesn't
         # have this issue because httplib doesn't attach this header automatically
-        if request.method == "POST":
+        if request.method == "POST" and not request.headers.get('Content-Type'):
             request.headers['Content-Type'] = ''
 
         # Convert body to bytes if needed


### PR DESCRIPTION
Fixes an issue where we shouldn't overwrite the header. Fixes this sentry error

https://sentry.infra.wish.com/sentry/merchant-frontend-production/issues/223427/?query=is:unresolved