### PR TITLE
automatically assume identity role on connection if token exists

### DIFF
--- a/boto/anon_connection.py
+++ b/boto/anon_connection.py
@@ -1,0 +1,230 @@
+from boto.connection import connection
+from boto.regioninfo import RegionInfo
+from boto.provider import NO_CREDENTIALS_PROVIDED
+from boto.credential_provider import CredentialProvider
+from boto.credentials import AssumedRole
+import boto.logs
+import xml.sax
+from boto.compat import six
+import threading
+from boto.exception import BotoServerError
+
+
+class AnonSTSConnection(connection):
+    """
+    AWS Security Token Service
+    The AWS Security Token Service is a web service that enables you
+    to request temporary, limited-privilege credentials for AWS
+    Identity and Access Management (IAM) users or for users that you
+    authenticate (federated users). This guide provides descriptions
+    of the AWS Security Token Service API.
+
+    For more detailed information about using this service, go to
+    `Using Temporary Security Credentials`_.
+
+    For information about setting up signatures and authorization
+    through the API, go to `Signing AWS API Requests`_ in the AWS
+    General Reference . For general information about the Query API,
+    go to `Making Query Requests`_ in Using IAM . For information
+    about using security tokens with other AWS products, go to `Using
+    Temporary Security Credentials to Access AWS`_ in Using Temporary
+    Security Credentials .
+
+    If you're new to AWS and need additional technical information
+    about a specific AWS product, you can find the product's technical
+    documentation at `http://aws.amazon.com/documentation/`_.
+
+    We will refer to Amazon Identity and Access Management using the
+    abbreviated form IAM. All copyrights and legal protections still
+    apply.
+    """
+    DefaultRegionName = 'us-east-1'
+    DefaultRegionEndpoint = 'sts.amazonaws.com'
+    APIVersion = '2011-06-15'
+
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
+                 is_secure=True, port=None, proxy=None, proxy_port=None,
+                 proxy_user=None, proxy_pass=None, debug=0,
+                 https_connection_factory=None, region=None, path='/',
+                 converter=None, validate_certs=True,
+                 security_token=None, profile_name=None):
+        """
+        :type anon: boolean
+        :param anon: If this parameter is True, the ``STSConnection`` object
+            will make anonymous requests, and it will not use AWS
+            Credentials or even search for AWS Credentials to make these
+            requests.
+        """
+        self.ResponseError=BotoServerError
+        if not region:
+            region = RegionInfo(self, self.DefaultRegionName,
+                                self.DefaultRegionEndpoint,
+                                connection_cls=AnonSTSConnection)
+        self.region = region
+        self._mutex = threading.Semaphore()
+        self.anon=True
+        # If an anonymous request is sent, do not try to look for credentials.
+        # So we pass in dummy values for the access key id, secret access
+        # key, and session token. It does not matter that they are
+        # not actual values because the request is anonymous.
+        provider = CredentialProvider('aws', NO_CREDENTIALS_PROVIDED,
+                                NO_CREDENTIALS_PROVIDED,
+                                NO_CREDENTIALS_PROVIDED)
+
+        super(AnonSTSConnection, self).__init__(self.region.endpoint,aws_access_key_id,
+                                    aws_secret_access_key,
+                                    is_secure, port, proxy, proxy_port,
+                                    proxy_user, proxy_pass,debug,
+                                    https_connection_factory, path,
+                                    validate_certs=validate_certs,
+                                    security_token=security_token,
+                                    profile_name=profile_name,
+                                    provider=provider)
+
+
+    def _required_auth_capability(self):
+        return ['sts-anon']
+
+    def assume_role_with_web_identity(self, role_arn, role_session_name,
+                                      web_identity_token, provider_id=None,
+                                      policy=None, duration_seconds=None):
+        """
+        Returns a set of temporary security credentials for users who
+        have been authenticated in a mobile or web application with a
+        web identity provider, such as Login with Amazon, Facebook, or
+        Google. `AssumeRoleWithWebIdentity` is an API call that does
+        not require the use of AWS security credentials. Therefore,
+        you can distribute an application (for example, on mobile
+        devices) that requests temporary security credentials without
+        including long-term AWS credentials in the application or by
+        deploying server-based proxy services that use long-term AWS
+        credentials. For more information, see `Creating a Mobile
+        Application with Third-Party Sign-In`_ in AWS Security Token
+        Service .
+
+        The temporary security credentials consist of an access key
+        ID, a secret access key, and a security token. Applications
+        can use these temporary security credentials to sign calls to
+        AWS service APIs. The credentials are valid for the duration
+        that you specified when calling `AssumeRoleWithWebIdentity`,
+        which can be from 900 seconds (15 minutes) to 3600 seconds (1
+        hour). By default, the temporary security credentials are
+        valid for 1 hour.
+
+        The temporary security credentials that are returned from the
+        `AssumeRoleWithWebIdentity` response have the permissions that
+        are associated with the access policy of the role being
+        assumed. You can further restrict the permissions of the
+        temporary security credentials by passing a policy in the
+        request. The resulting permissions are an intersection of the
+        role's access policy and the policy that you passed. These
+        policies and any applicable resource-based policies are
+        evaluated when calls to AWS service APIs are made using the
+        temporary security credentials.
+
+        Before your application can call `AssumeRoleWithWebIdentity`,
+        you must have an identity token from a supported identity
+        provider and create a role that the application can assume.
+        The role that your application assumes must trust the identity
+        provider that is associated with the identity token. In other
+        words, the identity provider must be specified in the role's
+        trust policy. For more information, see ` Creating Temporary
+        Security Credentials for Mobile Apps Using Third-Party
+        Identity Providers`_.
+
+        :type role_arn: string
+        :param role_arn: The Amazon Resource Name (ARN) of the role that the
+            caller is assuming.
+
+        :type role_session_name: string
+        :param role_session_name: An identifier for the assumed role session.
+            Typically, you pass the name or identifier that is associated with
+            the user who is using your application. That way, the temporary
+            security credentials that your application will use are associated
+            with that user. This session name is included as part of the ARN
+            and assumed role ID in the `AssumedRoleUser` response element.
+
+        :type web_identity_token: string
+        :param web_identity_token: The OAuth 2.0 access token or OpenID Connect
+            ID token that is provided by the identity provider. Your
+            application must get this token by authenticating the user who is
+            using your application with a web identity provider before the
+            application makes an `AssumeRoleWithWebIdentity` call.
+
+        :type provider_id: string
+        :param provider_id: Specify this value only for OAuth access tokens. Do
+            not specify this value for OpenID Connect ID tokens, such as
+            `accounts.google.com`. This is the fully-qualified host component
+            of the domain name of the identity provider. Do not include URL
+            schemes and port numbers. Currently, `www.amazon.com` and
+            `graph.facebook.com` are supported.
+
+        :type policy: string
+        :param policy: A supplemental policy that is associated with the
+            temporary security credentials from the `AssumeRoleWithWebIdentity`
+            call. The resulting permissions of the temporary security
+            credentials are an intersection of this policy and the access
+            policy that is associated with the role. Use this policy to further
+            restrict the permissions of the temporary security credentials.
+
+        :type duration_seconds: integer
+        :param duration_seconds: The duration, in seconds, of the role session.
+            The value can range from 900 seconds (15 minutes) to 3600 seconds
+            (1 hour). By default, the value is set to 3600 seconds.
+
+        """
+        params = {
+            'RoleArn': role_arn,
+            'RoleSessionName': role_session_name,
+            'WebIdentityToken': web_identity_token,
+        }
+        if provider_id is not None:
+            params['ProviderId'] = provider_id
+        if policy is not None:
+            params['Policy'] = policy
+        if duration_seconds is not None:
+            params['DurationSeconds'] = duration_seconds
+        return self.get_object(
+            'AssumeRoleWithWebIdentity',
+            params,
+            AssumedRole,
+            verb='POST'
+        )
+
+    def make_request(self, action, params=None, path='/', verb='GET',
+            override_timeout=None, override_num_retries=None):
+        http_request = self.build_base_http_request(
+            verb, path, None,
+            params, {}, '',
+            self.host)
+        if action:
+            http_request.params['Action'] = action
+        if self.APIVersion:
+            http_request.params['Version'] = self.APIVersion
+        return self._mexe(http_request)
+
+    def get_object(self, action, params, cls, path='/',
+                   parent=None, verb='GET', override_timeout=None,
+                   override_num_retries=None):
+        if not parent:
+            parent = self
+        response = self.make_request(action, params, path, verb,
+            override_timeout=override_timeout,
+            override_num_retries=override_num_retries)
+        body = response.read()
+        boto.log.debug(body)
+        if not body:
+            boto.log.error('Null body %s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+        elif response.status == 200:
+            obj = cls(parent)
+            h = boto.handler.XmlHandler(obj, parent)
+            if isinstance(body, six.text_type):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return obj
+        else:
+            boto.log.error('%s %s' % (response.status, response.reason))
+            boto.log.error('%s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -32,6 +32,7 @@ import boto.auth_handler
 import boto.exception
 import boto.plugin
 import boto.utils
+import boto.provider_util
 import copy
 import datetime
 from email.utils import formatdate
@@ -65,6 +66,7 @@ class HmacKeys(object):
     """Key based Auth handler helper."""
 
     def __init__(self, host, config, provider):
+
         if provider.access_key is None or provider.secret_key is None:
             raise boto.auth_handler.NotReadyToAuthenticate()
         self.host = host
@@ -72,6 +74,7 @@ class HmacKeys(object):
 
     def update_provider(self, provider):
         self._provider = provider
+
         self._hmac = hmac.new(self._provider.secret_key.encode('utf-8'),
                               digestmod=sha)
         if sha256:
@@ -148,7 +151,7 @@ class HmacAuthV1Handler(AuthHandler, HmacKeys):
         if self._provider.security_token:
             key = self._provider.security_token_header
             headers[key] = self._provider.security_token
-        string_to_sign = boto.utils.canonical_string(method, auth_path,
+        string_to_sign = boto.provider_util.canonical_string(method, auth_path,
                                                      headers, None,
                                                      self._provider)
         boto.log.debug('StringToSign:\n%s' % string_to_sign)

--- a/boto/aws_connection.py
+++ b/boto/aws_connection.py
@@ -1,0 +1,226 @@
+import os
+import xml.sax
+import boto.web_identity_provider
+from boto.provider import Provider
+from boto.resultset import ResultSet
+from boto.connection import connection
+from boto.compat import six
+from boto.exception import BotoServerError
+
+class AWSAuthConnection(connection):
+
+    def __init__(self, host, aws_access_key_id=None,
+                 aws_secret_access_key=None,
+                 is_secure=True, port=None, proxy=None, proxy_port=None,
+                 proxy_user=None, proxy_pass=None, debug=0,
+                 https_connection_factory=None, path='/',
+                 provider='aws', security_token=None,
+                 suppress_consec_slashes=True,
+                 validate_certs=True, profile_name=None):
+
+
+        web_identity_file='AWS_WEB_IDENTITY_TOKEN_FILE'
+
+        if web_identity_file in os.environ:
+            if isinstance(provider,Provider):
+                provider=boto.web_identity_provider.web_identity_credential_provider(provider.name,profile_name)
+            else:
+                provider=boto.web_identity_provider.web_identity_credential_provider(provider,profile_name)
+
+        super(AWSAuthConnection,self).__init__(host, aws_access_key_id,
+                 aws_secret_access_key,
+                 is_secure, port, proxy, proxy_port,
+                 proxy_user, proxy_pass, debug,
+                 https_connection_factory, path,
+                 provider, security_token,
+                 suppress_consec_slashes,
+                 validate_certs, profile_name)
+
+    def aws_access_key_id(self):
+        return self.provider.access_key
+    aws_access_key_id = property(aws_access_key_id)
+    gs_access_key_id = aws_access_key_id
+    access_key = aws_access_key_id
+
+    def aws_secret_access_key(self):
+        return self.provider.secret_key
+    aws_secret_access_key = property(aws_secret_access_key)
+    gs_secret_access_key = aws_secret_access_key
+    secret_key = aws_secret_access_key
+
+class AWSQueryConnection(AWSAuthConnection):
+
+    APIVersion = ''
+    ResponseError = BotoServerError
+
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
+                 is_secure=True, port=None, proxy=None, proxy_port=None,
+                 proxy_user=None, proxy_pass=None, host=None, debug=0,
+                 https_connection_factory=None, path='/', security_token=None,
+                 validate_certs=True, profile_name=None, provider='aws'):
+        super(AWSQueryConnection, self).__init__(
+            host, aws_access_key_id,
+            aws_secret_access_key,
+            is_secure, port, proxy,
+            proxy_port, proxy_user, proxy_pass,
+            debug, https_connection_factory, path,
+            security_token=security_token,
+            validate_certs=validate_certs,
+            profile_name=profile_name,
+            provider=provider)
+
+    def _required_auth_capability(self):
+        return []
+
+    def get_utf8_value(self, value):
+        return boto.utils.get_utf8_value(value)
+
+
+    def build_list_params(self, params, items, label):
+        if isinstance(items, six.string_types):
+            items = [items]
+        for i in range(1, len(items) + 1):
+            params['%s.%d' % (label, i)] = items[i - 1]
+
+    def build_complex_list_params(self, params, items, label, names):
+        """Serialize a list of structures.
+
+        For example::
+
+            items = [('foo', 'bar', 'baz'), ('foo2', 'bar2', 'baz2')]
+            label = 'ParamName.member'
+            names = ('One', 'Two', 'Three')
+            self.build_complex_list_params(params, items, label, names)
+
+        would result in the params dict being updated with these params::
+
+            ParamName.member.1.One = foo
+            ParamName.member.1.Two = bar
+            ParamName.member.1.Three = baz
+
+            ParamName.member.2.One = foo2
+            ParamName.member.2.Two = bar2
+            ParamName.member.2.Three = baz2
+
+        :type params: dict
+        :param params: The params dict.  The complex list params
+            will be added to this dict.
+
+        :type items: list of tuples
+        :param items: The list to serialize.
+
+        :type label: string
+        :param label: The prefix to apply to the parameter.
+
+        :type names: tuple of strings
+        :param names: The names associated with each tuple element.
+
+        """
+        for i, item in enumerate(items, 1):
+            current_prefix = '%s.%s' % (label, i)
+            for key, value in zip(names, item):
+                full_key = '%s.%s' % (current_prefix, key)
+                params[full_key] = value
+
+    # generics
+
+    def get_list(self, action, params, markers, path='/',
+                 parent=None, verb='GET'):
+        if not parent:
+            parent = self
+        response = self.make_request(action, params, path, verb)
+        body = response.read()
+        boto.log.debug(body)
+        if not body:
+            boto.log.error('Null body %s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+        elif response.status == 200:
+            rs = ResultSet(markers)
+            h = boto.handler.XmlHandler(rs, parent)
+            if isinstance(body, six.text_type):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return rs
+        else:
+            boto.log.error('%s %s' % (response.status, response.reason))
+            boto.log.error('%s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+
+    def get_object(self, action, params, cls, path='/',
+                   parent=None, verb='GET'):
+        if not parent:
+            parent = self
+        response = self.make_request(action, params, path, verb)
+        body = response.read()
+        boto.log.debug(body)
+        if not body:
+            boto.log.error('Null body %s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+        elif response.status == 200:
+            obj = cls(parent)
+            h = boto.handler.XmlHandler(obj, parent)
+            if isinstance(body, six.text_type):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return obj
+        else:
+            boto.log.error('%s %s' % (response.status, response.reason))
+            boto.log.error('%s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+
+    def get_status(self, action, params, path='/', parent=None, verb='GET'):
+        if not parent:
+            parent = self
+        response = self.make_request(action, params, path, verb)
+        body = response.read()
+        boto.log.debug(body)
+        if not body:
+            boto.log.error('Null body %s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+        elif response.status == 200:
+            rs = ResultSet()
+            h = boto.handler.XmlHandler(rs, parent)
+            xml.sax.parseString(body, h)
+            return rs.status
+        else:
+            boto.log.error('%s %s' % (response.status, response.reason))
+            boto.log.error('%s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+
+    def make_request(self, action, params=None, path='/', verb='GET',
+            override_timeout=None, override_num_retries=None):
+        http_request = self.build_base_http_request(
+            verb, path, None,
+            params, {}, '',
+            self.host)
+        if action:
+            http_request.params['Action'] = action
+        if self.APIVersion:
+            http_request.params['Version'] = self.APIVersion
+        return self._mexe(http_request, override_timeout=override_timeout,
+            override_num_retries=override_num_retries)
+
+    def get_object(self, action, params, cls, path='/',
+                   parent=None, verb='GET', override_timeout=None,
+                   override_num_retries=None):
+        if not parent:
+            parent = self
+        response = self.make_request(action, params, path, verb,
+            override_timeout=override_timeout,
+            override_num_retries=override_num_retries)
+        body = response.read()
+        boto.log.debug(body)
+        if not body:
+            boto.log.error('Null body %s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+        elif response.status == 200:
+            obj = cls(parent)
+            h = boto.handler.XmlHandler(obj, parent)
+            if isinstance(body, six.text_type):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return obj
+        else:
+            boto.log.error('%s %s' % (response.status, response.reason))
+            boto.log.error('%s' % body)
+            raise self.ResponseError(response.status, response.reason, body)

--- a/boto/awslambda/layer1.py
+++ b/boto/awslambda/layer1.py
@@ -23,7 +23,7 @@ import os
 
 from boto.compat import json
 from boto.exception import JSONResponseError
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.regioninfo import RegionInfo
 from boto.awslambda import exceptions
 

--- a/boto/beanstalk/layer1.py
+++ b/boto/beanstalk/layer1.py
@@ -26,7 +26,7 @@ import boto
 import boto.jsonresponse
 from boto.compat import json
 from boto.regioninfo import RegionInfo
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 
 
 class Layer1(AWSQueryConnection):

--- a/boto/cloudformation/connection.py
+++ b/boto/cloudformation/connection.py
@@ -24,7 +24,7 @@ import boto
 from boto.cloudformation.stack import Stack, StackSummary, StackEvent
 from boto.cloudformation.stack import StackResource, StackResourceSummary
 from boto.cloudformation.template import Template
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.compat import json
 

--- a/boto/cloudfront/__init__.py
+++ b/boto/cloudfront/__init__.py
@@ -23,7 +23,7 @@
 import xml.sax
 import time
 import boto
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto import handler
 from boto.cloudfront.distribution import Distribution, DistributionSummary, DistributionConfig
 from boto.cloudfront.distribution import StreamingDistribution, StreamingDistributionSummary, StreamingDistributionConfig

--- a/boto/cloudhsm/layer1.py
+++ b/boto/cloudhsm/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.cloudhsm import exceptions

--- a/boto/cloudsearch/layer1.py
+++ b/boto/cloudsearch/layer1.py
@@ -23,7 +23,7 @@
 
 import boto
 import boto.jsonresponse
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 
 #boto.set_stream_logger('cloudsearch')

--- a/boto/cloudsearch2/layer1.py
+++ b/boto/cloudsearch2/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.cloudsearch2 import exceptions

--- a/boto/cloudsearchdomain/layer1.py
+++ b/boto/cloudsearchdomain/layer1.py
@@ -21,7 +21,7 @@
 #
 from boto.compat import json
 from boto.exception import JSONResponseError
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.regioninfo import RegionInfo
 from boto.cloudsearchdomain import exceptions
 

--- a/boto/cloudtrail/layer1.py
+++ b/boto/cloudtrail/layer1.py
@@ -21,7 +21,7 @@
 #
 
 import boto
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.cloudtrail import exceptions

--- a/boto/codedeploy/layer1.py
+++ b/boto/codedeploy/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.codedeploy import exceptions

--- a/boto/cognito/identity/layer1.py
+++ b/boto/cognito/identity/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.cognito.identity import exceptions

--- a/boto/cognito/sync/layer1.py
+++ b/boto/cognito/sync/layer1.py
@@ -21,7 +21,7 @@
 #
 from boto.compat import json
 from boto.exception import JSONResponseError
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.regioninfo import RegionInfo
 from boto.cognito.sync import exceptions
 

--- a/boto/compat.py
+++ b/boto/compat.py
@@ -61,7 +61,15 @@ if six.PY3:
     StandardError = Exception
     long_type = int
     from configparser import ConfigParser
+    def ensure_unicode(s, encoding='utf-8', errors='strict'):
+        #NOOP in python 3 because every string is already unicode
+        return s
 else:
     StandardError = StandardError
     long_type = long
     from ConfigParser import SafeConfigParser as ConfigParser
+
+    def ensure_unicode(s, encoding='utf-8', errors='strict'):
+        if isinstance(s, six.text_type):
+            return s
+        return unicode(s, encoding, errors)

--- a/boto/configservice/layer1.py
+++ b/boto/configservice/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.configservice import exceptions

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -50,7 +50,6 @@ import re
 import socket
 import sys
 import time
-import xml.sax
 import copy
 
 from boto import auth
@@ -66,8 +65,8 @@ from boto.exception import AWSConnectionError
 from boto.exception import BotoClientError
 from boto.exception import BotoServerError
 from boto.exception import PleaseRetryException
+from boto.credential_provider import CredentialProvider
 from boto.provider import Provider
-from boto.resultset import ResultSet
 
 HAVE_HTTPS_CONNECTION = False
 try:
@@ -413,7 +412,7 @@ class HTTPResponse(http_client.HTTPResponse):
             return http_client.HTTPResponse.read(self, amt)
 
 
-class AWSAuthConnection(object):
+class connection(object):
     def __init__(self, host, aws_access_key_id=None,
                  aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
@@ -548,12 +547,11 @@ class AWSAuthConnection(object):
             self.provider = provider
         else:
             self._provider_type = provider
-            self.provider = Provider(self._provider_type,
+            self.provider = CredentialProvider(self._provider_type,
                                      aws_access_key_id,
                                      aws_secret_access_key,
                                      security_token,
                                      profile_name)
-
         # Allow config file to override default host, port, and host header.
         if self.provider.host:
             self.host = self.provider.host
@@ -561,6 +559,7 @@ class AWSAuthConnection(object):
             self.port = self.provider.port
         if self.provider.host_header:
             self.host_header = self.provider.host_header
+
 
         self._pool = ConnectionPool()
         self._connection = (self.host, self.port, self.is_secure)
@@ -599,16 +598,10 @@ class AWSAuthConnection(object):
     connection = property(connection)
 
     def aws_access_key_id(self):
-        return self.provider.access_key
-    aws_access_key_id = property(aws_access_key_id)
-    gs_access_key_id = aws_access_key_id
-    access_key = aws_access_key_id
+        pass
 
     def aws_secret_access_key(self):
-        return self.provider.secret_key
-    aws_secret_access_key = property(aws_secret_access_key)
-    gs_secret_access_key = aws_secret_access_key
-    secret_key = aws_secret_access_key
+        pass
 
     def profile_name(self):
         return self.provider.profile_name
@@ -706,7 +699,7 @@ class AWSAuthConnection(object):
                 override_timeout=override_timeout)
         else:
             return self.new_http_connection(host, port, is_secure,
-                override_timeout=override_timeout)
+                  override_timeout=override_timeout)
 
     def skip_proxy(self, host):
         if not self.no_proxy:
@@ -918,7 +911,6 @@ class AWSAuthConnection(object):
         connection = self.get_http_connection(request.host, request.port,
                                               self.is_secure,
                                               override_timeout=override_timeout)
-
         # Convert body to bytes if needed
         if not isinstance(request.body, bytes) and hasattr(request.body,
                                                            'encode'):
@@ -1087,159 +1079,3 @@ class AWSAuthConnection(object):
         self._connection = None  # compat field
 
 
-class AWSQueryConnection(AWSAuthConnection):
-
-    APIVersion = ''
-    ResponseError = BotoServerError
-
-    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
-                 is_secure=True, port=None, proxy=None, proxy_port=None,
-                 proxy_user=None, proxy_pass=None, host=None, debug=0,
-                 https_connection_factory=None, path='/', security_token=None,
-                 validate_certs=True, profile_name=None, provider='aws'):
-        super(AWSQueryConnection, self).__init__(
-            host, aws_access_key_id,
-            aws_secret_access_key,
-            is_secure, port, proxy,
-            proxy_port, proxy_user, proxy_pass,
-            debug, https_connection_factory, path,
-            security_token=security_token,
-            validate_certs=validate_certs,
-            profile_name=profile_name,
-            provider=provider)
-
-    def _required_auth_capability(self):
-        return []
-
-    def get_utf8_value(self, value):
-        return boto.utils.get_utf8_value(value)
-
-    def make_request(self, action, params=None, path='/', verb='GET',
-            override_timeout=None, override_num_retries=None):
-        http_request = self.build_base_http_request(
-            verb, path, None,
-            params, {}, '',
-            self.host)
-        if action:
-            http_request.params['Action'] = action
-        if self.APIVersion:
-            http_request.params['Version'] = self.APIVersion
-        return self._mexe(http_request, override_timeout=override_timeout,
-            override_num_retries=override_num_retries)
-
-    def build_list_params(self, params, items, label):
-        if isinstance(items, six.string_types):
-            items = [items]
-        for i in range(1, len(items) + 1):
-            params['%s.%d' % (label, i)] = items[i - 1]
-
-    def build_complex_list_params(self, params, items, label, names):
-        """Serialize a list of structures.
-
-        For example::
-
-            items = [('foo', 'bar', 'baz'), ('foo2', 'bar2', 'baz2')]
-            label = 'ParamName.member'
-            names = ('One', 'Two', 'Three')
-            self.build_complex_list_params(params, items, label, names)
-
-        would result in the params dict being updated with these params::
-
-            ParamName.member.1.One = foo
-            ParamName.member.1.Two = bar
-            ParamName.member.1.Three = baz
-
-            ParamName.member.2.One = foo2
-            ParamName.member.2.Two = bar2
-            ParamName.member.2.Three = baz2
-
-        :type params: dict
-        :param params: The params dict.  The complex list params
-            will be added to this dict.
-
-        :type items: list of tuples
-        :param items: The list to serialize.
-
-        :type label: string
-        :param label: The prefix to apply to the parameter.
-
-        :type names: tuple of strings
-        :param names: The names associated with each tuple element.
-
-        """
-        for i, item in enumerate(items, 1):
-            current_prefix = '%s.%s' % (label, i)
-            for key, value in zip(names, item):
-                full_key = '%s.%s' % (current_prefix, key)
-                params[full_key] = value
-
-    # generics
-
-    def get_list(self, action, params, markers, path='/',
-                 parent=None, verb='GET'):
-        if not parent:
-            parent = self
-        response = self.make_request(action, params, path, verb)
-        body = response.read()
-        boto.log.debug(body)
-        if not body:
-            boto.log.error('Null body %s' % body)
-            raise self.ResponseError(response.status, response.reason, body)
-        elif response.status == 200:
-            rs = ResultSet(markers)
-            h = boto.handler.XmlHandler(rs, parent)
-            if isinstance(body, six.text_type):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return rs
-        else:
-            boto.log.error('%s %s' % (response.status, response.reason))
-            boto.log.error('%s' % body)
-            raise self.ResponseError(response.status, response.reason, body)
-
-    def get_object(self, action, params, cls, path='/',
-                   parent=None, verb='GET', override_timeout=None,
-                   override_num_retries=None):
-        if not parent:
-            parent = self
-        response = self.make_request(action, params, path, verb,
-            override_timeout=override_timeout,
-            override_num_retries=override_num_retries)
-        body = response.read()
-        boto.log.debug(body)
-        if not body:
-            boto.log.error('Null body %s' % body)
-            raise self.ResponseError(response.status, response.reason, body)
-        elif response.status == 200:
-            obj = cls(parent)
-            h = boto.handler.XmlHandler(obj, parent)
-            if isinstance(body, six.text_type):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return obj
-        else:
-            boto.log.error('%s %s' % (response.status, response.reason))
-            boto.log.error('%s' % body)
-            raise self.ResponseError(response.status, response.reason, body)
-
-    def get_status(self, action, params, path='/', parent=None, verb='GET',
-            override_timeout=None, override_num_retries=None):
-        if not parent:
-            parent = self
-        response = self.make_request(action, params, path, verb,
-            override_timeout=override_timeout,
-            override_num_retries=override_num_retries)
-        body = response.read()
-        boto.log.debug(body)
-        if not body:
-            boto.log.error('Null body %s' % body)
-            raise self.ResponseError(response.status, response.reason, body)
-        elif response.status == 200:
-            rs = ResultSet()
-            h = boto.handler.XmlHandler(rs, parent)
-            xml.sax.parseString(body, h)
-            return rs.status
-        else:
-            boto.log.error('%s %s' % (response.status, response.reason))
-            boto.log.error('%s' % body)
-            raise self.ResponseError(response.status, response.reason, body)

--- a/boto/credential_provider.py
+++ b/boto/credential_provider.py
@@ -1,0 +1,214 @@
+import os
+import boto
+from datetime import datetime
+
+from boto.compat import expanduser
+from boto.pyami.config import Config
+from boto import config
+from boto.provider import Provider,ProfileNotFoundError
+
+
+class CredentialProvider(Provider):
+    def __init__(self, name, access_key=None, secret_key=None,
+                 security_token=None, profile_name=None,anon=False):
+
+        super(CredentialProvider,self).__init__(name,access_key=access_key,secret_key=secret_key,
+                                                security_token=security_token,profile_name=profile_name,anon=anon)
+
+        # Load shared credentials file if it exists
+        shared_path = os.path.join(expanduser('~'), '.' + name, 'credentials')
+        self.shared_credentials = Config(do_load=False)
+        if os.path.isfile(shared_path):
+            self.shared_credentials.load_from_path(shared_path)
+
+        self.get_credentials(access_key, secret_key, security_token, profile_name)
+
+    def get_access_key(self):
+
+        if self._credentials_need_refresh():
+            self._populate_keys_from_metadata_server()
+        return self._access_key
+
+    def set_access_key(self, value):
+        self._access_key = value
+
+    access_key = property(get_access_key, set_access_key)
+
+    def get_secret_key(self):
+        if self._credentials_need_refresh():
+            self._populate_keys_from_metadata_server()
+        return self._secret_key
+
+    def set_secret_key(self, value):
+        self._secret_key = value
+
+    secret_key = property(get_secret_key, set_secret_key)
+
+    def get_security_token(self):
+        if self._credentials_need_refresh():
+            self._populate_keys_from_metadata_server()
+        return self._security_token
+
+    def set_security_token(self, value):
+        self._security_token = value
+
+    security_token = property(get_security_token, set_security_token)
+
+    def _credentials_need_refresh(self):
+        if self._credential_expiry_time is None:
+            return False
+        else:
+            # The credentials should be refreshed if they're going to expire
+            # in less than 5 minutes.
+            delta = self._credential_expiry_time - datetime.utcnow()
+            # python2.6 does not have timedelta.total_seconds() so we have
+            # to calculate this ourselves.  This is straight from the
+            # datetime docs.
+            seconds_left = (
+                (delta.microseconds + (delta.seconds + delta.days * 24 * 3600)
+                 * 10 ** 6) / 10 ** 6)
+            if seconds_left < (5 * 60):
+                boto.log.debug("Credentials need to be refreshed.")
+                return True
+            else:
+                return False
+
+    def get_credentials(self, access_key=None, secret_key=None,
+                        security_token=None, profile_name=None):
+        access_key_name, secret_key_name, security_token_name, \
+            profile_name_name = self.CredentialMap[self.name]
+
+        # Load profile from shared environment variable if it was not
+        # already passed in and the environment variable exists
+        if profile_name is None and profile_name_name is not None and \
+           profile_name_name.upper() in os.environ:
+            profile_name = os.environ[profile_name_name.upper()]
+
+        shared = self.shared_credentials
+
+        if access_key is not None:
+            self.access_key = access_key
+            boto.log.debug("Using access key provided by client.")
+        elif access_key_name.upper() in os.environ:
+            self.access_key = os.environ[access_key_name.upper()]
+            boto.log.debug("Using access key found in environment variable.")
+        elif profile_name is not None:
+            if shared.has_option(profile_name, access_key_name):
+                self.access_key = shared.get(profile_name, access_key_name)
+                boto.log.debug("Using access key found in shared credential "
+                               "file for profile %s." % profile_name)
+            elif config.has_option("profile %s" % profile_name,
+                                   access_key_name):
+                self.access_key = config.get("profile %s" % profile_name,
+                                             access_key_name)
+                boto.log.debug("Using access key found in config file: "
+                               "profile %s." % profile_name)
+            else:
+                raise ProfileNotFoundError('Profile "%s" not found!' %
+                                           profile_name)
+        elif shared.has_option('default', access_key_name):
+            self.access_key = shared.get('default', access_key_name)
+            boto.log.debug("Using access key found in shared credential file.")
+        elif config.has_option('Credentials', access_key_name):
+            self.access_key = config.get('Credentials', access_key_name)
+            boto.log.debug("Using access key found in config file.")
+
+        if secret_key is not None:
+            self.secret_key = secret_key
+            boto.log.debug("Using secret key provided by client.")
+        elif secret_key_name.upper() in os.environ:
+            self.secret_key = os.environ[secret_key_name.upper()]
+            boto.log.debug("Using secret key found in environment variable.")
+        elif profile_name is not None:
+            if shared.has_option(profile_name, secret_key_name):
+                self.secret_key = shared.get(profile_name, secret_key_name)
+                boto.log.debug("Using secret key found in shared credential "
+                               "file for profile %s." % profile_name)
+            elif config.has_option("profile %s" % profile_name, secret_key_name):
+                self.secret_key = config.get("profile %s" % profile_name,
+                                             secret_key_name)
+                boto.log.debug("Using secret key found in config file: "
+                               "profile %s." % profile_name)
+            else:
+                raise ProfileNotFoundError('Profile "%s" not found!' %
+                                           profile_name)
+        elif shared.has_option('default', secret_key_name):
+            self.secret_key = shared.get('default', secret_key_name)
+            boto.log.debug("Using secret key found in shared credential file.")
+        elif config.has_option('Credentials', secret_key_name):
+            self.secret_key = config.get('Credentials', secret_key_name)
+            boto.log.debug("Using secret key found in config file.")
+        elif config.has_option('Credentials', 'keyring'):
+            keyring_name = config.get('Credentials', 'keyring')
+            try:
+                import keyring
+            except ImportError:
+                boto.log.error("The keyring module could not be imported. "
+                               "For keyring support, install the keyring "
+                               "module.")
+                raise
+            self.secret_key = keyring.get_password(
+                keyring_name, self.access_key)
+            boto.log.debug("Using secret key found in keyring.")
+
+        if security_token is not None:
+            self.security_token = security_token
+            boto.log.debug("Using security token provided by client.")
+        elif ((security_token_name is not None) and
+              (access_key is None) and (secret_key is None)):
+            # Only provide a token from the environment/config if the
+            # caller did not specify a key and secret.  Otherwise an
+            # environment/config token could be paired with a
+            # different set of credentials provided by the caller
+            if security_token_name.upper() in os.environ:
+                self.security_token = os.environ[security_token_name.upper()]
+                boto.log.debug("Using security token found in environment"
+                               " variable.")
+            elif shared.has_option(profile_name or 'default',
+                                   security_token_name):
+                self.security_token = shared.get(profile_name or 'default',
+                                                 security_token_name)
+                boto.log.debug("Using security token found in shared "
+                               "credential file.")
+            elif profile_name is not None:
+                if config.has_option("profile %s" % profile_name,
+                                     security_token_name):
+                    boto.log.debug("config has option")
+                    self.security_token = config.get("profile %s" % profile_name,
+                                                     security_token_name)
+                    boto.log.debug("Using security token found in config file: "
+                                   "profile %s." % profile_name)
+            elif config.has_option('Credentials', security_token_name):
+                self.security_token = config.get('Credentials',
+                                                 security_token_name)
+                boto.log.debug("Using security token found in config file.")
+
+        if ((self._access_key is None or self._secret_key is None) and
+                self.MetadataServiceSupport[self.name]):
+            self._populate_keys_from_metadata_server()
+        self._secret_key = self._convert_key_to_str(self._secret_key)
+
+    def _populate_keys_from_metadata_server(self):
+        # get_instance_metadata is imported here because of a circular
+        # dependency.
+        boto.log.debug("Retrieving credentials from metadata server.")
+        from boto.utils import get_instance_metadata
+        timeout = config.getfloat('Boto', 'metadata_service_timeout', 1.0)
+        attempts = config.getint('Boto', 'metadata_service_num_attempts', 1)
+        # The num_retries arg is actually the total number of attempts made,
+        # so the config options is named *_num_attempts to make this more
+        # clear to users.
+        metadata = get_instance_metadata(
+            timeout=timeout, num_retries=attempts,
+            data='meta-data/iam/security-credentials/')
+        if metadata:
+            # I'm assuming there's only one role on the instance profile.
+            security = list(metadata.values())[0]
+            self._access_key = security['AccessKeyId']
+            self._secret_key = self._convert_key_to_str(security['SecretAccessKey'])
+            self._security_token = security['Token']
+            expires_at = security['Expiration']
+            self._credential_expiry_time = datetime.strptime(
+                expires_at, "%Y-%m-%dT%H:%M:%SZ")
+            boto.log.debug("Retrieved credentials will expire in %s at: %s",
+                           self._credential_expiry_time - datetime.now(), expires_at)

--- a/boto/credentials.py
+++ b/boto/credentials.py
@@ -1,0 +1,822 @@
+# Copyright (c) 2011 Mitch Garnaat http://garnaat.org/
+# Copyright (c) 2011, Eucalyptus Systems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+File containing classes used in AssumeRoleWithWebIdentity, including credential objects, refreshable credentials and credntial provider.
+Content of this file is backported from botocore, which is used by boto3.
+
+https://github.com/boto/botocore/blob/08d0e5995284656895f5c8a0bddd8c386a8483c4/botocore/credentials.py#L353
+"""
+
+import time
+import os
+import datetime
+import threading
+from dateutil.tz import tzlocal
+from dateutil.parser import parse
+from collections import namedtuple
+from copy import deepcopy
+from hashlib import sha1
+
+import boto.utils
+import boto
+from boto import config
+from boto.compat import json
+from boto.exception import CredentialRetrievalError,InvalidConfigError
+
+
+ReadOnlyCredentials = namedtuple('ReadOnlyCredentials',
+                                 ['access_key', 'secret_key', 'token'])
+
+class FileWebIdentityTokenLoader(object):
+    def __init__(self, web_identity_token_path, _open=open):
+        self._web_identity_token_path = web_identity_token_path
+        self._open = _open
+
+    def __call__(self):
+        with self._open(self._web_identity_token_path) as token_file:
+            return token_file.read()
+
+
+class Credentials(object):
+    """
+    :ivar access_key: The AccessKeyID.
+    :ivar secret_key: The SecretAccessKey.
+    :ivar session_token: The session token that must be passed with
+                         requests to use the temporary credentials
+    :ivar expiration: The timestamp for when the credentials will expire
+    """
+
+    def __init__(self, parent=None, access_key=None, secret_key=None):
+        self.parent = parent
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.session_token = None
+        self.expiration = None
+        self.request_id = None
+
+        self._normalize()
+
+    def __getitem__(self, item):
+        if not isinstance(item,str):
+            raise TypeError('Index must be a string, not {}'.format(type(item)))
+        item = item.lower()
+        return getattr(self,item)
+
+    @classmethod
+    def from_json(cls, json_doc):
+        """
+        Create and return a new Session Token based on the contents
+        of a JSON document.
+
+        :type json_doc: str
+        :param json_doc: A string containing a JSON document with a
+            previously saved Credentials object.
+        """
+        d = json.loads(json_doc)
+        token = cls()
+        token.__dict__.update(d)
+        return token
+
+    @classmethod
+    def load(cls, file_path):
+        """
+        Create and return a new Session Token based on the contents
+        of a previously saved JSON-format file.
+
+        :type file_path: str
+        :param file_path: The fully qualified path to the JSON-format
+            file containing the previously saved Session Token information.
+        """
+        fp = open(file_path)
+        json_doc = fp.read()
+        fp.close()
+        return cls.from_json(json_doc)
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'AccessKeyId':
+            self.access_key = value
+        elif name == 'SecretAccessKey':
+            self.secret_key = value
+        elif name == 'SessionToken':
+            self.session_token = value
+        elif name == 'Expiration':
+            self.expiration = value
+        elif name == 'RequestId':
+            self.request_id = value
+        else:
+            pass
+
+    def to_dict(self):
+        """
+        Return a Python dict containing the important information
+        about this Session Token.
+        """
+        return {'access_key': self.access_key,
+                'secret_key': self.secret_key,
+                'session_token': self.session_token,
+                'expiration': self.expiration,
+                'request_id': self.request_id}
+
+    def save(self, file_path):
+        """
+        Persist a Session Token to a file in JSON format.
+
+        :type path: str
+        :param path: The fully qualified path to the file where the
+            the Session Token data should be written.  Any previous
+            data in the file will be overwritten.  To help protect
+            the credentials contained in the file, the permissions
+            of the file will be set to readable/writable by owner only.
+        """
+        fp = open(file_path, 'w')
+        json.dump(self.to_dict(), fp)
+        fp.close()
+        os.chmod(file_path, 0o600)
+
+    def is_expired(self, time_offset_seconds=0):
+        """
+        Checks to see if the Session Token is expired or not.  By default
+        it will check to see if the Session Token is expired as of the
+        moment the method is called.  However, you can supply an
+        optional parameter which is the number of seconds of offset
+        into the future for the check.  For example, if you supply
+        a value of 5, this method will return a True if the Session
+        Token will be expired 5 seconds from this moment.
+
+        :type time_offset_seconds: int
+        :param time_offset_seconds: The number of seconds into the future
+            to test the Session Token for expiration.
+        """
+        now = datetime.datetime.utcnow()
+        if time_offset_seconds:
+            now = now + datetime.timedelta(seconds=time_offset_seconds)
+        ts = boto.utils.parse_ts(self.expiration)
+        delta = ts - now
+        return delta.total_seconds() <= 0
+
+    def _normalize(self):
+        # Keys would sometimes (accidentally) contain non-ascii characters.
+        # It would cause a confusing UnicodeDecodeError in Python 2.
+        # We explicitly convert them into unicode to avoid such error.
+        #
+        # Eventually the service will decide whether to accept the credential.
+        # This also complies with the behavior in Python 3.
+        if self.access_key is not None:
+            self.access_key = boto.compat.ensure_unicode(self.access_key)
+        if self.secret_key is not None:
+            self.secret_key = boto.compat.ensure_unicode(self.secret_key)
+
+    def get_frozen_credentials(self):
+        return ReadOnlyCredentials(self.access_key,
+                                   self.secret_key,
+                                   self.token)
+
+def _local_now():
+    return datetime.datetime.now(tzlocal())
+
+def total_seconds(delta):
+    """
+    Returns the total seconds in a ``datetime.timedelta``.
+
+    This used to be a compat shim for 2.6 but is now just an alias.
+
+    :param delta: The timedelta object
+    :type delta: ``datetime.timedelta``
+    """
+    return delta.total_seconds()
+
+def _serialize_if_needed(value, iso=False):
+    if isinstance(value, datetime.datetime):
+        if iso:
+            return value.isoformat()
+        return value.strftime('%Y-%m-%dT%H:%M:%S%Z')
+    return value
+
+def _parse_if_needed(value):
+    if isinstance(value, datetime.datetime):
+        return value
+    return parse(value)
+
+class RefreshableCredentials(Credentials):
+    """
+    Holds the credentials needed to authenticate requests. In addition, it
+    knows how to refresh itself.
+
+    :ivar access_key: The access key part of the credentials.
+    :ivar secret_key: The secret key part of the credentials.
+    :ivar token: The security token, valid only for session credentials.
+    :ivar method: A string which identifies where the credentials
+        were found.
+    """
+    # The time at which we'll attempt to refresh, but not
+    # block if someone else is refreshing.
+    _advisory_refresh_timeout = 10 * 60
+    # The time at which all threads will block waiting for
+    # refreshed credentials.
+    _mandatory_refresh_timeout = 15 * 60
+
+    def __init__(self, access_key, secret_key, token,
+                 expiry_time, refresh_using, method,
+                 time_fetcher=_local_now):
+        self._refresh_using = refresh_using
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._token = token
+        self._expiry_time = expiry_time
+        self._time_fetcher = time_fetcher
+        self._refresh_lock = threading.Lock()
+        self.method = method
+        self._frozen_credentials = ReadOnlyCredentials(
+            access_key, secret_key, token)
+        self._normalize()
+
+    def _normalize(self):
+        pass
+
+    @classmethod
+    def create_from_metadata(cls, metadata, refresh_using, method):
+        instance = cls(
+            access_key=metadata['access_key'],
+            secret_key=metadata['secret_key'],
+            token=metadata['token'],
+            expiry_time=cls._expiry_datetime(metadata['expiry_time']),
+            method=method,
+            refresh_using=refresh_using
+        )
+        return instance
+
+    @property
+    def access_key(self):
+        """Warning: Using this property can lead to race conditions if you
+        access another property subsequently along the refresh boundary.
+        Please use get_frozen_credentials instead.
+        """
+        self._refresh()
+        return self._access_key
+
+    @access_key.setter
+    def access_key(self, value):
+        self._access_key = value
+
+    @property
+    def secret_key(self):
+        """Warning: Using this property can lead to race conditions if you
+        access another property subsequently along the refresh boundary.
+        Please use get_frozen_credentials instead.
+        """
+        self._refresh()
+        return self._secret_key
+
+    @secret_key.setter
+    def secret_key(self, value):
+        self._secret_key = value
+
+    @property
+    def token(self):
+        """Warning: Using this property can lead to race conditions if you
+        access another property subsequently along the refresh boundary.
+        Please use get_frozen_credentials instead.
+        """
+        self._refresh()
+        return self._token
+
+    @token.setter
+    def token(self, value):
+        self._token = value
+
+    def _seconds_remaining(self):
+        delta = self._expiry_time - self._time_fetcher()
+        return total_seconds(delta)
+
+    def refresh_needed(self, refresh_in=None):
+        """Check if a refresh is needed.
+
+        A refresh is needed if the expiry time associated
+        with the temporary credentials is less than the
+        provided ``refresh_in``.  If ``time_delta`` is not
+        provided, ``self.advisory_refresh_needed`` will be used.
+
+        For example, if your temporary credentials expire
+        in 10 minutes and the provided ``refresh_in`` is
+        ``15 * 60``, then this function will return ``True``.
+
+        :type refresh_in: int
+        :param refresh_in: The number of seconds before the
+            credentials expire in which refresh attempts should
+            be made.
+
+        :return: True if refresh needed, False otherwise.
+
+        """
+        if self._expiry_time is None:
+            # No expiration, so assume we don't need to refresh.
+            return False
+
+        if refresh_in is None:
+            refresh_in = self._advisory_refresh_timeout
+        # The credentials should be refreshed if they're going to expire
+        # in less than 5 minutes.
+        if self._seconds_remaining() >= refresh_in:
+            # There's enough time left. Don't refresh.
+            return False
+
+        return True
+
+    def _is_expired(self):
+        # Checks if the current credentials are expired.
+        return self.refresh_needed(refresh_in=0)
+
+    def _refresh(self):
+        # In the common case where we don't need a refresh, we
+        # can immediately exit and not require acquiring the
+        # refresh lock.
+        if not self.refresh_needed(self._advisory_refresh_timeout):
+            return
+
+        # acquire() doesn't accept kwargs, but False is indicating
+        # that we should not block if we can't acquire the lock.
+        # If we aren't able to acquire the lock, we'll trigger
+        # the else clause.
+        if self._refresh_lock.acquire(False):
+            try:
+                if not self.refresh_needed(self._advisory_refresh_timeout):
+                    return
+                is_mandatory_refresh = self.refresh_needed(
+                    self._mandatory_refresh_timeout)
+                self._protected_refresh(is_mandatory=is_mandatory_refresh)
+                return
+            finally:
+                self._refresh_lock.release()
+        elif self.refresh_needed(self._mandatory_refresh_timeout):
+            # If we're within the mandatory refresh window,
+            # we must block until we get refreshed credentials.
+            with self._refresh_lock:
+                if not self.refresh_needed(self._mandatory_refresh_timeout):
+                    return
+                self._protected_refresh(is_mandatory=True)
+
+    def _protected_refresh(self, is_mandatory):
+        # precondition: this method should only be called if you've acquired
+        # the self._refresh_lock.
+        try:
+            metadata = self._refresh_using()
+        except Exception as e:
+            period_name = 'mandatory' if is_mandatory else 'advisory'
+            if is_mandatory:
+                # If this is a mandatory refresh, then
+                # all errors that occur when we attempt to refresh
+                # credentials are propagated back to the user.
+                raise
+            # Otherwise we'll just return.
+            # The end result will be that we'll use the current
+            # set of temporary credentials we have.
+            return
+        self._set_from_data(metadata)
+        self._frozen_credentials = ReadOnlyCredentials(
+            self._access_key, self._secret_key, self._token)
+        if self._is_expired():
+            # We successfully refreshed credentials but for whatever
+            # reason, our refreshing function returned credentials
+            # that are still expired.  In this scenario, the only
+            # thing we can do is let the user know and raise
+            # an exception.
+            msg = ("Credentials were refreshed, but the "
+                   "refreshed credentials are still expired.")
+            raise RuntimeError(msg)
+
+    @staticmethod
+    def _expiry_datetime(time_str):
+        return parse(time_str)
+
+    def _set_from_data(self, data):
+        expected_keys = ['access_key', 'secret_key', 'token', 'expiry_time']
+        if not data:
+            missing_keys = expected_keys
+        else:
+            missing_keys = [k for k in expected_keys if k not in data]
+
+        if missing_keys:
+            message = "Credential refresh failed, response did not contain: %s"
+            raise CredentialRetrievalError(
+                provider=self.method,
+                message=message % ', '.join(missing_keys),
+            )
+
+        self.access_key = data['access_key']
+        self.secret_key = data['secret_key']
+        self.token = data['token']
+        self._expiry_time = parse(data['expiry_time'])
+        boto.log.debug("Retrieved credentials will expire at: %s",
+                     self._expiry_time)
+        self._normalize()
+
+    def get_frozen_credentials(self):
+        """Return immutable credentials.
+
+        The ``access_key``, ``secret_key``, and ``token`` properties
+        on this class will always check and refresh credentials if
+        needed before returning the particular credentials.
+
+        This has an edge case where you can get inconsistent
+        credentials.  Imagine this:
+
+            # Current creds are "t1"
+            tmp.access_key  ---> expired? no, so return t1.access_key
+            # ---- time is now expired, creds need refreshing to "t2" ----
+            tmp.secret_key  ---> expired? yes, refresh and return t2.secret_key
+
+        This means we're using the access key from t1 with the secret key
+        from t2.  To fix this issue, you can request a frozen credential object
+        which is guaranteed not to change.
+
+        The frozen credentials returned from this method should be used
+        immediately and then discarded.  The typical usage pattern would
+        be::
+
+            creds = RefreshableCredentials(...)
+            some_code = SomeSignerObject()
+            # I'm about to sign the request.
+            # The frozen credentials are only used for the
+            # duration of generate_presigned_url and will be
+            # immediately thrown away.
+            request = some_code.sign_some_request(
+                with_credentials=creds.get_frozen_credentials())
+            print("Signed request:", request)
+
+        """
+        self._refresh()
+        return self._frozen_credentials
+
+
+class DeferredRefreshableCredentials(RefreshableCredentials):
+    """Refreshable credentials that don't require initial credentials.
+
+    refresh_using will be called upon first access.
+    """
+    def __init__(self, refresh_using, method, time_fetcher=_local_now):
+        self._refresh_using = refresh_using
+        self._access_key = None
+        self._secret_key = None
+        self._token = None
+        self._expiry_time = None
+        self._time_fetcher = time_fetcher
+        self._refresh_lock = threading.Lock()
+        self.method = method
+        self._frozen_credentials = None
+
+    def refresh_needed(self, refresh_in=None):
+        if self._frozen_credentials is None:
+            return True
+        return super(DeferredRefreshableCredentials, self).refresh_needed(
+            refresh_in
+        )
+
+
+class CachedCredentialFetcher(object):
+    DEFAULT_EXPIRY_WINDOW_SECONDS = 60 * 15
+
+    def __init__(self, cache=None, expiry_window_seconds=None):
+        if cache is None:
+            cache = {}
+        self._cache = cache
+        self._cache_key = self._create_cache_key()
+        if expiry_window_seconds is None:
+            expiry_window_seconds = self.DEFAULT_EXPIRY_WINDOW_SECONDS
+        self._expiry_window_seconds = expiry_window_seconds
+
+    def _create_cache_key(self):
+        raise NotImplementedError('_create_cache_key()')
+
+    def _make_file_safe(self, filename):
+        # Replace :, path sep, and / to make it the string filename safe.
+        filename = filename.replace(':', '_').replace(os.path.sep, '_')
+        return filename.replace('/', '_')
+
+    def _get_credentials(self):
+        raise NotImplementedError('_get_credentials()')
+
+    def fetch_credentials(self):
+        return self._get_cached_credentials()
+
+    def _get_cached_credentials(self):
+        """Get up-to-date credentials.
+
+        This will check the cache for up-to-date credentials, calling assume
+        role if none are available.
+        """
+        response = self._load_from_cache()
+        if response is None:
+            response = self._get_credentials()
+            self._write_to_cache(response)
+        else:
+            boto.log.debug("Credentials for role retrieved from cache.")
+
+        if isinstance(response,AssumedRole):
+            creds=response.credentials.to_dict()
+        else:
+            creds = response['Credentials']
+
+        expiration = _serialize_if_needed(creds['expiration'], iso=True)
+        return {
+            'access_key': creds['access_key'],
+            'secret_key': creds['secret_key'],
+            'token': creds['session_token'],
+            'expiry_time': expiration,
+        }
+
+    def _load_from_cache(self):
+        if self._cache_key in self._cache:
+            creds = deepcopy(self._cache[self._cache_key])
+            if not self._is_expired(creds):
+                return creds
+            else:
+                boto.log.debug(
+                    "Credentials were found in cache, but they are expired."
+                )
+        return None
+
+    def _write_to_cache(self, response):
+        self._cache[self._cache_key] = deepcopy(response)
+
+    def _is_expired(self, credentials):
+        """Check if credentials are expired."""
+        end_time = _parse_if_needed(credentials['Credentials']['expiration'])
+        seconds = total_seconds(end_time - _local_now())
+        return seconds < self._expiry_window_seconds
+
+
+class BaseAssumeRoleCredentialFetcher(CachedCredentialFetcher):
+    def __init__(self, connection_class, role_arn, extra_args=None,
+                 cache=None, expiry_window_seconds=None):
+        self._connction_class = connection_class
+        self._role_arn = role_arn
+
+        if extra_args is None:
+            self._assume_kwargs = {}
+        else:
+            self._assume_kwargs = deepcopy(extra_args)
+        self._assume_kwargs['RoleArn'] = self._role_arn
+
+        self._role_session_name = self._assume_kwargs.get('RoleSessionName')
+        self._using_default_session_name = False
+        if not self._role_session_name:
+            self._generate_assume_role_name()
+
+        super(BaseAssumeRoleCredentialFetcher, self).__init__(
+            cache, expiry_window_seconds
+        )
+
+    def _generate_assume_role_name(self):
+        self._role_session_name = 'botocore-session-%s' % (int(time.time()))
+        self._assume_kwargs['RoleSessionName'] = self._role_session_name
+        self._using_default_session_name = True
+
+    def _create_cache_key(self):
+        """Create a predictable cache key for the current configuration.
+
+        The cache key is intended to be compatible with file names.
+        """
+        args = deepcopy(self._assume_kwargs)
+
+        # The role session name gets randomly generated, so we don't want it
+        # in the hash.
+        if self._using_default_session_name:
+            del args['RoleSessionName']
+
+        if 'Policy' in args:
+            # To have a predictable hash, the keys of the policy must be
+            # sorted, so we have to load it here to make sure it gets sorted
+            # later on.
+            args['Policy'] = json.loads(args['Policy'])
+
+        args = json.dumps(args, sort_keys=True)
+        argument_hash = sha1(args.encode('utf-8')).hexdigest()
+        return self._make_file_safe(argument_hash)
+
+class AssumeRoleWithWebIdentityCredentialFetcher(
+        BaseAssumeRoleCredentialFetcher
+):
+    def __init__(self, connection_class, web_identity_token_loader, role_arn,
+                 extra_args=None, cache=None, expiry_window_seconds=None):
+        """
+        :type connection_class: callable
+        :param connection_class: A callable that creates a client taking
+            arguments like connection_class(**kwargs)
+
+        :type web_identity_token_loader: callable
+        :param web_identity_token_loader: A callable that takes no arguments
+        and returns a web identity token str.
+
+        :type role_arn: str
+        :param role_arn: The ARN of the role to be assumed.
+
+        :type extra_args: dict
+        :param extra_args: Any additional arguments to add to the assume
+            role request using the format of the botocore operation.
+            Possible keys include, but may not be limited to,
+            DurationSeconds, Policy, SerialNumber, ExternalId and
+            RoleSessionName.
+
+        :type cache: dict
+        :param cache: An object that supports ``__getitem__``,
+            ``__setitem__``, and ``__contains__``.  An example of this is
+            the ``JSONFileCache`` class in aws-cli.
+
+        :type expiry_window_seconds: int
+        :param expiry_window_seconds: The amount of time, in seconds,
+        """
+        self._web_identity_token_loader = web_identity_token_loader
+
+        super(AssumeRoleWithWebIdentityCredentialFetcher, self).__init__(
+            connection_class, role_arn, extra_args=extra_args,
+            cache=cache, expiry_window_seconds=expiry_window_seconds
+        )
+
+    def _get_credentials(self):
+        """Get credentials by calling assume role."""
+        kwargs = self._assume_web_identity_role_kwargs()
+        # Assume role with web identity does not require credentials other than
+        # the token, explicitly configure the client to not sign requests.
+
+        connection=self._connction_class()
+        return connection.assume_role_with_web_identity(**kwargs)
+
+    def _assume_role_kwargs(self):
+        """Get the arguments for assume role based on current configuration."""
+        assume_role_kwargs = deepcopy(self._assume_kwargs)
+        identity_token = self._web_identity_token_loader()
+        assume_role_kwargs['WebIdentityToken'] = identity_token
+
+        return assume_role_kwargs
+
+    def _assume_web_identity_role_kwargs(self):
+        return {
+            'web_identity_token':self._web_identity_token_loader(),
+            'role_arn':self._role_arn,
+            'role_session_name': self._role_session_name
+
+        }
+
+class AssumeRoleWithWebIdentityProvider(object):
+    METHOD = 'assume-role-with-web-identity'
+    CANONICAL_NAME = None
+    _CONFIG_TO_ENV_VAR = {
+        'web_identity_token_file': 'AWS_WEB_IDENTITY_TOKEN_FILE',
+        'role_session_name': 'AWS_ROLE_SESSION_NAME',
+        'role_arn': 'AWS_ROLE_ARN',
+    }
+
+    def __init__(
+            self,
+            connection,
+            profile_name,
+            cache=None,
+            load_config=None,
+            disable_env_vars=False,
+            token_loader_cls=None,
+    ):
+        self.cache = cache
+        self._connection = connection
+        self._load_config = load_config
+        self._profile_name = profile_name
+        self._profile_config = None
+        self._disable_env_vars = disable_env_vars
+        if token_loader_cls is None:
+            token_loader_cls = FileWebIdentityTokenLoader
+        self._token_loader_cls = token_loader_cls
+
+    def load(self):
+        return self._assume_role_with_web_identity()
+
+
+    def _get_profile_config(self, key):
+        if self._profile_config is None and self._load_config is not None:
+            print type(self._load_config)
+            loaded_config = self._load_config()
+            profiles = loaded_config.get('profiles', {})
+            self._profile_config = profiles.get(self._profile_name, {})
+        return self._profile_config.get(key) if self._profile_config else None
+
+    def _get_env_config(self, key):
+        if self._disable_env_vars:
+            return None
+        env_key = self._CONFIG_TO_ENV_VAR.get(key)
+        if env_key and env_key in os.environ:
+            return os.environ[env_key]
+        return None
+
+    def _get_config(self, key):
+        env_value = self._get_env_config(key)
+        if env_value is not None:
+            return env_value
+        return self._get_profile_config(key)
+
+
+    def _assume_role_with_web_identity(self):
+        token_path = self._get_config('web_identity_token_file')
+        if not token_path:
+            return None
+        token_loader = self._token_loader_cls(token_path)
+
+        role_arn = self._get_config('role_arn')
+        if not role_arn:
+            error_msg = (
+                'The provided profile or the current environment is '
+                'configured to assume role with web identity but has no '
+                'role ARN configured. Ensure that the profile has the role_arn'
+                'configuration set or the AWS_ROLE_ARN env var is set.'
+            )
+            raise InvalidConfigError(message=error_msg)
+
+        extra_args = {}
+        role_session_name = self._get_config('role_session_name')
+        if role_session_name is not None:
+            extra_args['RoleSessionName'] = role_session_name
+
+        fetcher = AssumeRoleWithWebIdentityCredentialFetcher(
+            connection_class=self._connection,
+            web_identity_token_loader=token_loader,
+            role_arn=role_arn,
+            extra_args=extra_args,
+            cache=self.cache,
+        )
+        # The initial credentials are empty and the expiration time is set
+        # to now so that we can delay the call to assume role until it is
+        # strictly needed.
+        return DeferredRefreshableCredentials(
+            method=self.METHOD,
+            refresh_using=fetcher.fetch_credentials,
+        )
+
+
+class User(object):
+    """
+    :ivar arn: The arn of the user assuming the role.
+    :ivar assume_role_id: The identifier of the assumed role.
+    """
+    def __init__(self, arn=None, assume_role_id=None):
+        self.arn = arn
+        self.assume_role_id = assume_role_id
+
+    def startElement(self, name, attrs, connection):
+        pass
+
+    def endElement(self, name, value, connection):
+        if name == 'Arn':
+            self.arn = value
+        elif name == 'AssumedRoleId':
+            self.assume_role_id = value
+
+
+class AssumedRole(object):
+    """
+    :ivar user: The assumed role user.
+    :ivar credentials: A Credentials object containing the credentials.
+    """
+    def __init__(self, connection=None, credentials=None, user=None):
+        self._connection = connection
+        self.credentials = credentials
+        self.user = user
+
+    def startElement(self, name, attrs, connection):
+        if name == 'Credentials':
+            self.credentials = Credentials()
+            return self.credentials
+        elif name == 'AssumedRoleUser':
+            self.user = User()
+            return self.user
+
+    def endElement(self, name, value, connection):
+        pass
+
+    def __deepcopy__(self, memodict={}):
+        return AssumedRole(self._connection,deepcopy(self.credentials,memodict),deepcopy(self.user,memodict))
+
+    def __getitem__(self, item):
+        if not isinstance(item,str):
+            raise TypeError('Index must be a string, not {}'.format(type(item)))
+        item = item.lower()
+        return getattr(self,item)

--- a/boto/datapipeline/layer1.py
+++ b/boto/datapipeline/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.datapipeline import exceptions

--- a/boto/directconnect/layer1.py
+++ b/boto/directconnect/layer1.py
@@ -21,7 +21,7 @@
 #
 
 import boto
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.directconnect import exceptions

--- a/boto/dynamodb/layer1.py
+++ b/boto/dynamodb/layer1.py
@@ -24,7 +24,7 @@ import time
 from binascii import crc32
 
 import boto
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.exception import DynamoDBResponseError
 from boto.provider import Provider
 from boto.dynamodb import exceptions as dynamodb_exceptions

--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -23,7 +23,7 @@ from binascii import crc32
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.dynamodb2 import exceptions

--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -30,7 +30,7 @@ Auto Scaling service.
 import base64
 
 import boto
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo, get_regions, load_regions
 from boto.ec2.autoscale.request import Request
 from boto.ec2.autoscale.launchconfig import LaunchConfiguration

--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -24,7 +24,7 @@ This module provides an interface to the Elastic Compute Cloud (EC2)
 CloudWatch service from AWS.
 """
 from boto.compat import json, map, six, zip
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.ec2.cloudwatch.metric import Metric
 from boto.ec2.cloudwatch.alarm import MetricAlarm, MetricAlarms, AlarmHistoryItem
 from boto.ec2.cloudwatch.datapoint import Datapoint

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -32,7 +32,7 @@ from datetime import timedelta
 
 import boto
 from boto.auth import detect_potential_sigv4
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.resultset import ResultSet
 from boto.ec2.image import Image, ImageAttribute, CopyImage
 from boto.ec2.instance import Reservation, Instance

--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -25,7 +25,7 @@
 This module provides an interface to the Elastic Compute Cloud (EC2)
 load balancing service from AWS.
 """
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.ec2.instanceinfo import InstanceInfo
 from boto.ec2.elb.loadbalancer import LoadBalancer, LoadBalancerZones
 from boto.ec2.elb.instancestate import InstanceState

--- a/boto/ec2containerservice/layer1.py
+++ b/boto/ec2containerservice/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.ec2containerservice import exceptions

--- a/boto/ecs/__init__.py
+++ b/boto/ecs/__init__.py
@@ -20,7 +20,7 @@
 # IN THE SOFTWARE.
 
 import boto
-from boto.connection import AWSQueryConnection, AWSAuthConnection
+from boto.aws_connection import AWSQueryConnection, AWSAuthConnection
 from boto.exception import BotoServerError
 import time
 import urllib

--- a/boto/elasticache/layer1.py
+++ b/boto/elasticache/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 
 

--- a/boto/elastictranscoder/layer1.py
+++ b/boto/elastictranscoder/layer1.py
@@ -21,7 +21,7 @@
 #
 from boto.compat import json
 from boto.exception import JSONResponseError
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.regioninfo import RegionInfo
 from boto.elastictranscoder import exceptions
 

--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -35,7 +35,7 @@ from boto.emr.emrobject import AddInstanceGroupsResponse, BootstrapActionList, \
                                ModifyInstanceGroupsResponse, \
                                RunJobFlowResponse, StepSummaryList
 from boto.emr.step import JarStep
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.exception import EmrResponseError
 from boto.compat import six
 

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -466,6 +466,12 @@ class InvalidAclError(Exception):
         super(InvalidAclError, self).__init__(message)
         self.message = message
 
+class InvalidConfigError(Exception):
+    """Exception raised when the configuration to get credentials is invalid"""
+
+    def __init__(self, message):
+        super(InvalidConfigError,self).__init__(message)
+        self.message=message
 
 class InvalidCorsError(Exception):
     """Exception raised when CORS XML is invalid."""
@@ -570,4 +576,22 @@ class PleaseRetryException(Exception):
         return 'PleaseRetryException("%s", %s)' % (
             self.message,
             self.response
+        )
+
+class CredentialRetrievalError(Exception):
+    """
+    Error attempting to retrieve credentials from a remote source.
+
+    :ivar provider: The name of the credential provider.
+    :ivar error_msg: The msg explaining why credentials could not be
+        retrieved.
+
+    """
+    def __init__(self,provider, message):
+        self.message = message
+        self.provider = provider
+    def __repr__(self):
+        return 'Error when retrieving credentials from %s: %s' % (
+            self.provider,
+            self.message
         )

--- a/boto/fps/connection.py
+++ b/boto/fps/connection.py
@@ -23,7 +23,7 @@
 
 import urllib
 import uuid
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.fps.exception import ResponseErrorFactory
 from boto.fps.response import ResponseFactory
 import boto.fps.response

--- a/boto/glacier/layer1.py
+++ b/boto/glacier/layer1.py
@@ -26,7 +26,7 @@ import os
 
 import boto.glacier
 from boto.compat import json
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.glacier.exceptions import UnexpectedHTTPResponseError
 from boto.glacier.response import GlacierResponse
 from boto.glacier.utils import ResettingFileSender

--- a/boto/gs/resumable_upload_handler.py
+++ b/boto/gs/resumable_upload_handler.py
@@ -28,7 +28,7 @@ import time
 import urlparse
 from hashlib import md5
 from boto import config, UserAgent
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.exception import InvalidUriError
 from boto.exception import ResumableTransferDisposition
 from boto.exception import ResumableUploadException

--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -24,7 +24,7 @@ import boto.jsonresponse
 from boto.compat import json, six
 from boto.resultset import ResultSet
 from boto.iam.summarymap import SummaryMap
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 
 DEFAULT_POLICY_DOCUMENTS = {
     'default': {

--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -23,7 +23,7 @@
 import base64
 import boto
 
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.kinesis import exceptions

--- a/boto/kms/layer1.py
+++ b/boto/kms/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.kms import exceptions

--- a/boto/logs/layer1.py
+++ b/boto/logs/layer1.py
@@ -21,7 +21,7 @@
 #
 
 import boto
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.logs import exceptions

--- a/boto/machinelearning/layer1.py
+++ b/boto/machinelearning/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json, urlsplit
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.machinelearning import exceptions

--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -26,7 +26,7 @@ from boto import handler
 from boto import config
 from boto.mturk.price import Price
 import boto.mturk.notification
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.exception import EC2ResponseError
 from boto.resultset import ResultSet
 from boto.mturk.question import QuestionForm, ExternalQuestion, HTMLQuestion

--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -22,7 +22,7 @@ import xml.sax
 import hashlib
 import string
 import collections
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.exception import BotoServerError
 import boto.mws.exception
 import boto.mws.response

--- a/boto/opsworks/layer1.py
+++ b/boto/opsworks/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.opsworks import exceptions

--- a/boto/provider.py
+++ b/boto/provider.py
@@ -26,14 +26,11 @@
 This class encapsulates the provider-specific header differences.
 """
 
-import os
+
 from boto.compat import six
-from datetime import datetime
 
 import boto
 from boto import config
-from boto.compat import expanduser
-from boto.pyami.config import Config
 from boto.gs.acl import ACL
 from boto.gs.acl import CannedACLStrings as CannedGSACLStrings
 from boto.s3.acl import CannedACLStrings as CannedS3ACLStrings
@@ -177,8 +174,8 @@ class Provider(object):
         }
     }
 
-    def __init__(self, name, access_key=None, secret_key=None,
-                 security_token=None, profile_name=None):
+    def  __init__(self, name, access_key=None, secret_key=None,
+                 security_token=None, profile_name=None,anon=False):
         self.host = None
         self.port = None
         self.host_header = None
@@ -190,14 +187,8 @@ class Provider(object):
         self.acl_class = self.AclClassMap[self.name]
         self.canned_acls = self.CannedAclsMap[self.name]
         self._credential_expiry_time = None
+        self.anon = anon
 
-        # Load shared credentials file if it exists
-        shared_path = os.path.join(expanduser('~'), '.' + name, 'credentials')
-        self.shared_credentials = Config(do_load=False)
-        if os.path.isfile(shared_path):
-            self.shared_credentials.load_from_path(shared_path)
-
-        self.get_credentials(access_key, secret_key, security_token, profile_name)
         self.configure_headers()
         self.configure_errors()
 
@@ -212,194 +203,6 @@ class Provider(object):
         if config.has_option('Credentials', host_header_opt_name):
             self.host_header = config.get('Credentials', host_header_opt_name)
 
-    def get_access_key(self):
-        if self._credentials_need_refresh():
-            self._populate_keys_from_metadata_server()
-        return self._access_key
-
-    def set_access_key(self, value):
-        self._access_key = value
-
-    access_key = property(get_access_key, set_access_key)
-
-    def get_secret_key(self):
-        if self._credentials_need_refresh():
-            self._populate_keys_from_metadata_server()
-        return self._secret_key
-
-    def set_secret_key(self, value):
-        self._secret_key = value
-
-    secret_key = property(get_secret_key, set_secret_key)
-
-    def get_security_token(self):
-        if self._credentials_need_refresh():
-            self._populate_keys_from_metadata_server()
-        return self._security_token
-
-    def set_security_token(self, value):
-        self._security_token = value
-
-    security_token = property(get_security_token, set_security_token)
-
-    def _credentials_need_refresh(self):
-        if self._credential_expiry_time is None:
-            return False
-        else:
-            # The credentials should be refreshed if they're going to expire
-            # in less than 5 minutes.
-            delta = self._credential_expiry_time - datetime.utcnow()
-            # python2.6 does not have timedelta.total_seconds() so we have
-            # to calculate this ourselves.  This is straight from the
-            # datetime docs.
-            seconds_left = (
-                (delta.microseconds + (delta.seconds + delta.days * 24 * 3600)
-                 * 10 ** 6) / 10 ** 6)
-            if seconds_left < (5 * 60):
-                boto.log.debug("Credentials need to be refreshed.")
-                return True
-            else:
-                return False
-
-    def get_credentials(self, access_key=None, secret_key=None,
-                        security_token=None, profile_name=None):
-        access_key_name, secret_key_name, security_token_name, \
-            profile_name_name = self.CredentialMap[self.name]
-
-        # Load profile from shared environment variable if it was not
-        # already passed in and the environment variable exists
-        if profile_name is None and profile_name_name is not None and \
-           profile_name_name.upper() in os.environ:
-            profile_name = os.environ[profile_name_name.upper()]
-
-        shared = self.shared_credentials
-
-        if access_key is not None:
-            self.access_key = access_key
-            boto.log.debug("Using access key provided by client.")
-        elif access_key_name.upper() in os.environ:
-            self.access_key = os.environ[access_key_name.upper()]
-            boto.log.debug("Using access key found in environment variable.")
-        elif profile_name is not None:
-            if shared.has_option(profile_name, access_key_name):
-                self.access_key = shared.get(profile_name, access_key_name)
-                boto.log.debug("Using access key found in shared credential "
-                               "file for profile %s." % profile_name)
-            elif config.has_option("profile %s" % profile_name,
-                                   access_key_name):
-                self.access_key = config.get("profile %s" % profile_name,
-                                             access_key_name)
-                boto.log.debug("Using access key found in config file: "
-                               "profile %s." % profile_name)
-            else:
-                raise ProfileNotFoundError('Profile "%s" not found!' %
-                                           profile_name)
-        elif shared.has_option('default', access_key_name):
-            self.access_key = shared.get('default', access_key_name)
-            boto.log.debug("Using access key found in shared credential file.")
-        elif config.has_option('Credentials', access_key_name):
-            self.access_key = config.get('Credentials', access_key_name)
-            boto.log.debug("Using access key found in config file.")
-
-        if secret_key is not None:
-            self.secret_key = secret_key
-            boto.log.debug("Using secret key provided by client.")
-        elif secret_key_name.upper() in os.environ:
-            self.secret_key = os.environ[secret_key_name.upper()]
-            boto.log.debug("Using secret key found in environment variable.")
-        elif profile_name is not None:
-            if shared.has_option(profile_name, secret_key_name):
-                self.secret_key = shared.get(profile_name, secret_key_name)
-                boto.log.debug("Using secret key found in shared credential "
-                               "file for profile %s." % profile_name)
-            elif config.has_option("profile %s" % profile_name, secret_key_name):
-                self.secret_key = config.get("profile %s" % profile_name,
-                                             secret_key_name)
-                boto.log.debug("Using secret key found in config file: "
-                               "profile %s." % profile_name)
-            else:
-                raise ProfileNotFoundError('Profile "%s" not found!' %
-                                           profile_name)
-        elif shared.has_option('default', secret_key_name):
-            self.secret_key = shared.get('default', secret_key_name)
-            boto.log.debug("Using secret key found in shared credential file.")
-        elif config.has_option('Credentials', secret_key_name):
-            self.secret_key = config.get('Credentials', secret_key_name)
-            boto.log.debug("Using secret key found in config file.")
-        elif config.has_option('Credentials', 'keyring'):
-            keyring_name = config.get('Credentials', 'keyring')
-            try:
-                import keyring
-            except ImportError:
-                boto.log.error("The keyring module could not be imported. "
-                               "For keyring support, install the keyring "
-                               "module.")
-                raise
-            self.secret_key = keyring.get_password(
-                keyring_name, self.access_key)
-            boto.log.debug("Using secret key found in keyring.")
-
-        if security_token is not None:
-            self.security_token = security_token
-            boto.log.debug("Using security token provided by client.")
-        elif ((security_token_name is not None) and
-              (access_key is None) and (secret_key is None)):
-            # Only provide a token from the environment/config if the
-            # caller did not specify a key and secret.  Otherwise an
-            # environment/config token could be paired with a
-            # different set of credentials provided by the caller
-            if security_token_name.upper() in os.environ:
-                self.security_token = os.environ[security_token_name.upper()]
-                boto.log.debug("Using security token found in environment"
-                               " variable.")
-            elif shared.has_option(profile_name or 'default',
-                                   security_token_name):
-                self.security_token = shared.get(profile_name or 'default',
-                                                 security_token_name)
-                boto.log.debug("Using security token found in shared "
-                               "credential file.")
-            elif profile_name is not None:
-                if config.has_option("profile %s" % profile_name,
-                                     security_token_name):
-                    boto.log.debug("config has option")
-                    self.security_token = config.get("profile %s" % profile_name,
-                                                     security_token_name)
-                    boto.log.debug("Using security token found in config file: "
-                                   "profile %s." % profile_name)
-            elif config.has_option('Credentials', security_token_name):
-                self.security_token = config.get('Credentials',
-                                                 security_token_name)
-                boto.log.debug("Using security token found in config file.")
-
-        if ((self._access_key is None or self._secret_key is None) and
-                self.MetadataServiceSupport[self.name]):
-            self._populate_keys_from_metadata_server()
-        self._secret_key = self._convert_key_to_str(self._secret_key)
-
-    def _populate_keys_from_metadata_server(self):
-        # get_instance_metadata is imported here because of a circular
-        # dependency.
-        boto.log.debug("Retrieving credentials from metadata server.")
-        from boto.utils import get_instance_metadata
-        timeout = config.getfloat('Boto', 'metadata_service_timeout', 1.0)
-        attempts = config.getint('Boto', 'metadata_service_num_attempts', 1)
-        # The num_retries arg is actually the total number of attempts made,
-        # so the config options is named *_num_attempts to make this more
-        # clear to users.
-        metadata = get_instance_metadata(
-            timeout=timeout, num_retries=attempts,
-            data='meta-data/iam/security-credentials/')
-        if metadata:
-            # I'm assuming there's only one role on the instance profile.
-            security = list(metadata.values())[0]
-            self._access_key = security['AccessKeyId']
-            self._secret_key = self._convert_key_to_str(security['SecretAccessKey'])
-            self._security_token = security['Token']
-            expires_at = security['Expiration']
-            self._credential_expiry_time = datetime.strptime(
-                expires_at, "%Y-%m-%dT%H:%M:%SZ")
-            boto.log.debug("Retrieved credentials will expire in %s at: %s",
-                           self._credential_expiry_time - datetime.now(), expires_at)
 
     def _convert_key_to_str(self, key):
         if isinstance(key, six.text_type):
@@ -446,7 +249,23 @@ class Provider(object):
     def supports_chunked_transfer(self):
         return self.ChunkedTransferSupport[self.name]
 
+    def get_access_key(self):
+        pass
 
+    def set_access_key(self, value):
+        pass
+
+    def get_security_token(self):
+        pass
+
+    def set_security_token(self, value):
+        pass
+
+    def get_secret_key(self):
+        pass
+
+    def set_secret_key(self, value):
+        pass
 # Static utility method for getting default Provider.
 def get_default():
     return Provider('aws')

--- a/boto/provider_util.py
+++ b/boto/provider_util.py
@@ -1,0 +1,120 @@
+import boto.provider
+from boto.compat import urllib
+
+
+qsa_of_interest = ['acl', 'cors', 'defaultObjectAcl', 'location', 'logging',
+                   'partNumber', 'policy', 'requestPayment', 'torrent',
+                   'versioning', 'versionId', 'versions', 'website',
+                   'uploads', 'uploadId', 'response-content-type',
+                   'response-content-language', 'response-expires',
+                   'response-cache-control', 'response-content-disposition',
+                   'response-content-encoding', 'delete', 'lifecycle',
+                   'tagging', 'restore',
+                   # storageClass is a QSA for buckets in Google Cloud Storage.
+                   # (StorageClass is associated to individual keys in S3, but
+                   # having it listed here should cause no problems because
+                   # GET bucket?storageClass is not part of the S3 API.)
+                   'storageClass',
+                   # websiteConfig is a QSA for buckets in Google Cloud
+                   # Storage.
+                   'websiteConfig',
+                   # compose is a QSA for objects in Google Cloud Storage.
+                   'compose']
+
+
+def unquote_v(nv):
+    if len(nv) == 1:
+        return nv
+    else:
+        return (nv[0], urllib.parse.unquote(nv[1]))
+
+
+def canonical_string(method, path, headers, expires=None,
+                     provider=None):
+    """
+    Generates the aws canonical string for the given parameters
+    """
+    if not provider:
+        provider = boto.provider.get_default()
+    interesting_headers = {}
+    for key in headers:
+        lk = key.lower()
+        if headers[key] is not None and \
+                (lk in ['content-md5', 'content-type', 'date'] or
+                 lk.startswith(provider.header_prefix)):
+            interesting_headers[lk] = str(headers[key]).strip()
+
+    # these keys get empty strings if they don't exist
+    if 'content-type' not in interesting_headers:
+        interesting_headers['content-type'] = ''
+    if 'content-md5' not in interesting_headers:
+        interesting_headers['content-md5'] = ''
+
+    # just in case someone used this.  it's not necessary in this lib.
+    if provider.date_header in interesting_headers:
+        interesting_headers['date'] = ''
+
+    # if you're using expires for query string auth, then it trumps date
+    # (and provider.date_header)
+    if expires:
+        interesting_headers['date'] = str(expires)
+
+    sorted_header_keys = sorted(interesting_headers.keys())
+
+    buf = "%s\n" % method
+    for key in sorted_header_keys:
+        val = interesting_headers[key]
+        if key.startswith(provider.header_prefix):
+            buf += "%s:%s\n" % (key, val)
+        else:
+            buf += "%s\n" % val
+
+    # don't include anything after the first ? in the resource...
+    # unless it is one of the QSA of interest, defined above
+    t = path.split('?')
+    buf += t[0]
+
+    if len(t) > 1:
+        qsa = t[1].split('&')
+        qsa = [a.split('=', 1) for a in qsa]
+        qsa = [unquote_v(a) for a in qsa if a[0] in qsa_of_interest]
+        if len(qsa) > 0:
+            qsa.sort(key=lambda x: x[0])
+            qsa = ['='.join(a) for a in qsa]
+            buf += '?'
+            buf += '&'.join(qsa)
+
+    return buf
+
+
+def merge_meta(headers, metadata, provider=None):
+    if not provider:
+        provider = boto.provider.get_default()
+    metadata_prefix = provider.metadata_prefix
+    final_headers = headers.copy()
+    for k in metadata.keys():
+        if k.lower() in boto.s3.key.Key.base_user_settable_fields:
+            final_headers[k] = metadata[k]
+        else:
+            final_headers[metadata_prefix + k] = metadata[k]
+
+    return final_headers
+
+
+def get_aws_metadata(headers, provider=None):
+    if not provider:
+        provider = boto.provider.get_default()
+    metadata_prefix = provider.metadata_prefix
+    metadata = {}
+    for hkey in headers.keys():
+        if hkey.lower().startswith(metadata_prefix):
+            val = urllib.parse.unquote(headers[hkey])
+            if isinstance(val, bytes):
+                try:
+                    val = val.decode('utf-8')
+                except UnicodeDecodeError:
+                    # Just leave the value as-is
+                    pass
+            metadata[hkey[len(metadata_prefix):]] = val
+            del headers[hkey]
+    return metadata

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -21,7 +21,7 @@
 #
 
 import urllib
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.rds.dbinstance import DBInstance
 from boto.rds.dbsecuritygroup import DBSecurityGroup
 from boto.rds.optiongroup  import OptionGroup, OptionGroupOption

--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -21,7 +21,7 @@
 #
 
 import boto
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.rds2 import exceptions

--- a/boto/redshift/layer1.py
+++ b/boto/redshift/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.redshift import exceptions

--- a/boto/route53/connection.py
+++ b/boto/route53/connection.py
@@ -30,7 +30,7 @@ import uuid
 import xml.sax
 
 import boto
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto import handler
 import boto.jsonresponse
 from boto.route53.record import ResourceRecordSets

--- a/boto/route53/domains/layer1.py
+++ b/boto/route53/domains/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.route53.domains import exceptions

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -43,6 +43,7 @@ from boto.s3.bucketlogging import BucketLogging
 from boto.s3 import website
 import boto.jsonresponse
 import boto.utils
+import boto.provider_util
 import xml.sax
 import xml.sax.saxutils
 import re
@@ -203,7 +204,7 @@ class Bucket(object):
         if response.status / 100 == 2:
             k = self.key_class(self)
             provider = self.connection.provider
-            k.metadata = boto.utils.get_aws_metadata(response.msg, provider)
+            k.metadata = boto.provider_util.get_aws_metadata(response.msg, provider)
             for field in Key.base_fields:
                 k.__dict__[field.lower().replace('-', '_')] = \
                     response.getheader(field)
@@ -863,7 +864,7 @@ class Bucket(object):
             headers[provider.storage_class_header] = storage_class
         if metadata is not None:
             headers[provider.metadata_directive_header] = 'REPLACE'
-            headers = boto.utils.merge_meta(headers, metadata, provider)
+            headers = boto.provider_util.merge_meta(headers, metadata, provider)
         elif not query_args:  # Can't use this header with multi-part copy.
             headers[provider.metadata_directive_header] = 'COPY'
         response = self.connection.make_request('PUT', self.name, new_key_name,
@@ -1746,7 +1747,7 @@ class Bucket(object):
         if metadata is None:
             metadata = {}
 
-        headers = boto.utils.merge_meta(headers, metadata,
+        headers = boto.provider_util.merge_meta(headers, metadata,
                 self.connection.provider)
         response = self.connection.make_request('POST', self.name, key_name,
                                                 query_args=query_args,

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -29,7 +29,8 @@ import time
 
 from boto.auth import detect_potential_s3sigv4
 import boto.utils
-from boto.connection import AWSAuthConnection
+import boto.provider_util
+from boto.aws_connection import AWSAuthConnection
 from boto import handler
 from boto.s3.bucket import Bucket
 from boto.s3.key import Key
@@ -403,7 +404,7 @@ class S3Connection(AWSAuthConnection):
         if extra_qp:
             delimiter = '?' if '?' not in auth_path else '&'
             auth_path += delimiter + '&'.join(extra_qp)
-        c_string = boto.utils.canonical_string(method, auth_path, headers,
+        c_string = boto.provider_util.canonical_string(method, auth_path, headers,
                                                expires, self.provider)
         b64_hmac = self._auth_handler.sign_string(c_string)
         encoded_canonical = urllib.parse.quote(b64_hmac, safe='')

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -31,6 +31,7 @@ import binascii
 import math
 from hashlib import md5
 import boto.utils
+import boto.provider_util
 from boto.compat import BytesIO, six, urllib, encodebytes
 
 from boto.exception import BotoClientError
@@ -302,7 +303,7 @@ class Key(object):
                 raise provider.storage_response_error(self.resp.status,
                                                       self.resp.reason, body)
             response_headers = self.resp.msg
-            self.metadata = boto.utils.get_aws_metadata(response_headers,
+            self.metadata = boto.provider_utils.get_aws_metadata(response_headers,
                                                         provider)
             for name, value in response_headers.items():
                 # To get correct size for Range GETs, use Content-Range
@@ -696,7 +697,7 @@ class Key(object):
                 headers[provider.storage_class_header] = self.storage_class
         if encrypt_key:
             headers[provider.server_side_encryption_header] = 'AES256'
-        headers = boto.utils.merge_meta(headers, self.metadata, provider)
+        headers = boto.provider_util.merge_meta(headers, self.metadata, provider)
 
         return self.bucket.connection.generate_url(expires_in, method,
                                                    self.bucket.name, self.name,
@@ -941,7 +942,7 @@ class Key(object):
                 kwargs['size'] = size
             headers['_sha256'] = compute_hash(**kwargs)[0]
         headers['Expect'] = '100-Continue'
-        headers = boto.utils.merge_meta(headers, self.metadata, provider)
+        headers = boto.provider_util.merge_meta(headers, self.metadata, provider)
         resp = self.bucket.connection.make_request(
             'PUT',
             self.bucket.name,

--- a/boto/s3/resumable_download_handler.py
+++ b/boto/s3/resumable_download_handler.py
@@ -26,7 +26,7 @@ import socket
 import time
 import boto
 from boto import config, storage_uri_for_key
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.exception import ResumableDownloadException
 from boto.exception import ResumableTransferDisposition
 from boto.s3.keyfile import KeyFile

--- a/boto/sdb/connection.py
+++ b/boto/sdb/connection.py
@@ -22,7 +22,7 @@ import xml.sax
 import threading
 import boto
 from boto import handler
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.sdb.domain import Domain, DomainMetaData
 from boto.sdb.item import Item
 from boto.sdb.regioninfo import SDBRegionInfo

--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -23,7 +23,7 @@ import re
 import base64
 
 from boto.compat import six, urllib
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.exception import BotoServerError
 from boto.regioninfo import RegionInfo
 import boto

--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -23,7 +23,7 @@
 import uuid
 import hashlib
 
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.compat import json
 import boto

--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -20,7 +20,7 @@
 # IN THE SOFTWARE.
 
 import boto
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.sqs.regioninfo import SQSRegionInfo
 from boto.sqs.queue import Queue
 from boto.sqs.message import Message

--- a/boto/sts/__init__.py
+++ b/boto/sts/__init__.py
@@ -32,6 +32,7 @@ def regions():
     :return: A list of :class:`boto.regioninfo.RegionInfo` instances
     """
     return get_regions('sts', connection_cls=STSConnection)
+    pass
 
 
 def connect_to_region(region_name, **kw_params):

--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -21,11 +21,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from boto.connection import AWSQueryConnection
+
+from boto.aws_connection import AWSQueryConnection
+
 from boto.provider import Provider, NO_CREDENTIALS_PROVIDED
 from boto.regioninfo import RegionInfo
-from boto.sts.credentials import Credentials, FederationToken, AssumedRole
+from boto.sts.credentials import Credentials, FederationToken
 from boto.sts.credentials import DecodeAuthorizationMessage
+from boto.credentials import AssumedRole
 import boto
 import boto.utils
 import datetime

--- a/boto/sts/credentials.py
+++ b/boto/sts/credentials.py
@@ -177,27 +177,6 @@ class FederationToken(object):
             pass
 
 
-class AssumedRole(object):
-    """
-    :ivar user: The assumed role user.
-    :ivar credentials: A Credentials object containing the credentials.
-    """
-    def __init__(self, connection=None, credentials=None, user=None):
-        self._connection = connection
-        self.credentials = credentials
-        self.user = user
-
-    def startElement(self, name, attrs, connection):
-        if name == 'Credentials':
-            self.credentials = Credentials()
-            return self.credentials
-        elif name == 'AssumedRoleUser':
-            self.user = User()
-            return self.user
-
-    def endElement(self, name, value, connection):
-        pass
-
 
 class User(object):
     """

--- a/boto/support/layer1.py
+++ b/boto/support/layer1.py
@@ -22,7 +22,7 @@
 
 import boto
 from boto.compat import json
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.support import exceptions

--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -25,7 +25,7 @@
 import time
 
 import boto
-from boto.connection import AWSAuthConnection
+from boto.aws_connection import AWSAuthConnection
 from boto.provider import Provider
 from boto.exception import SWFResponseError
 from boto.swf import exceptions as swf_exceptions

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -43,7 +43,6 @@ import subprocess
 import time
 import logging.handlers
 import boto
-import boto.provider
 import tempfile
 import random
 import smtplib
@@ -95,104 +94,6 @@ qsa_of_interest = ['acl', 'cors', 'defaultObjectAcl', 'location', 'logging',
 _first_cap_regex = re.compile('(.)([A-Z][a-z]+)')
 _number_cap_regex = re.compile('([a-z])([0-9]+)')
 _end_cap_regex = re.compile('([a-z0-9])([A-Z])')
-
-
-def unquote_v(nv):
-    if len(nv) == 1:
-        return nv
-    else:
-        return (nv[0], urllib.parse.unquote(nv[1]))
-
-
-def canonical_string(method, path, headers, expires=None,
-                     provider=None):
-    """
-    Generates the aws canonical string for the given parameters
-    """
-    if not provider:
-        provider = boto.provider.get_default()
-    interesting_headers = {}
-    for key in headers:
-        lk = key.lower()
-        if headers[key] is not None and \
-                (lk in ['content-md5', 'content-type', 'date'] or
-                 lk.startswith(provider.header_prefix)):
-            interesting_headers[lk] = str(headers[key]).strip()
-
-    # these keys get empty strings if they don't exist
-    if 'content-type' not in interesting_headers:
-        interesting_headers['content-type'] = ''
-    if 'content-md5' not in interesting_headers:
-        interesting_headers['content-md5'] = ''
-
-    # just in case someone used this.  it's not necessary in this lib.
-    if provider.date_header in interesting_headers:
-        interesting_headers['date'] = ''
-
-    # if you're using expires for query string auth, then it trumps date
-    # (and provider.date_header)
-    if expires:
-        interesting_headers['date'] = str(expires)
-
-    sorted_header_keys = sorted(interesting_headers.keys())
-
-    buf = "%s\n" % method
-    for key in sorted_header_keys:
-        val = interesting_headers[key]
-        if key.startswith(provider.header_prefix):
-            buf += "%s:%s\n" % (key, val)
-        else:
-            buf += "%s\n" % val
-
-    # don't include anything after the first ? in the resource...
-    # unless it is one of the QSA of interest, defined above
-    t = path.split('?')
-    buf += t[0]
-
-    if len(t) > 1:
-        qsa = t[1].split('&')
-        qsa = [a.split('=', 1) for a in qsa]
-        qsa = [unquote_v(a) for a in qsa if a[0] in qsa_of_interest]
-        if len(qsa) > 0:
-            qsa.sort(key=lambda x: x[0])
-            qsa = ['='.join(a) for a in qsa]
-            buf += '?'
-            buf += '&'.join(qsa)
-
-    return buf
-
-
-def merge_meta(headers, metadata, provider=None):
-    if not provider:
-        provider = boto.provider.get_default()
-    metadata_prefix = provider.metadata_prefix
-    final_headers = headers.copy()
-    for k in metadata.keys():
-        if k.lower() in boto.s3.key.Key.base_user_settable_fields:
-            final_headers[k] = metadata[k]
-        else:
-            final_headers[metadata_prefix + k] = metadata[k]
-
-    return final_headers
-
-
-def get_aws_metadata(headers, provider=None):
-    if not provider:
-        provider = boto.provider.get_default()
-    metadata_prefix = provider.metadata_prefix
-    metadata = {}
-    for hkey in headers.keys():
-        if hkey.lower().startswith(metadata_prefix):
-            val = urllib.parse.unquote(headers[hkey])
-            if isinstance(val, bytes):
-                try:
-                    val = val.decode('utf-8')
-                except UnicodeDecodeError:
-                    # Just leave the value as-is
-                    pass
-            metadata[hkey[len(metadata_prefix):]] = val
-            del headers[hkey]
-    return metadata
 
 
 def retry_url(url, retry_on_404=True, num_retries=10, timeout=None):
@@ -497,6 +398,7 @@ def update_dme(username, password, dme_id, ip_address):
     dme_url += '?username=%s&password=%s&id=%s&ip=%s'
     s = urllib.request.urlopen(dme_url % (username, password, dme_id, ip_address))
     return s.read()
+
 
 
 def fetch_file(uri, file=None, username=None, password=None):

--- a/boto/web_identity_provider.py
+++ b/boto/web_identity_provider.py
@@ -1,0 +1,40 @@
+import boto.anon_connection
+from boto.credentials import AssumeRoleWithWebIdentityProvider
+from boto.provider import Provider
+
+class web_identity_credential_provider(Provider):
+    def __init__(self, name, profile_name):
+        super(web_identity_credential_provider,self).__init__(name, profile_name=profile_name)
+        self.access_key = None,
+        self.secret_key = None,
+        self.security_token = None,
+        self._expiry_time = None
+        connection = boto.anon_connection.AnonSTSConnection
+        self._credentials = AssumeRoleWithWebIdentityProvider(connection, profile_name).load()
+
+
+    def get_access_key(self):
+        return self._credentials.get_frozen_credentials().access_key
+
+
+    def set_access_key(self, value):
+        self._access_key = value
+
+    access_key = property(get_access_key, set_access_key)
+
+    def get_secret_key(self):
+        return self._credentials.get_frozen_credentials().secret_key
+
+    def set_secret_key(self, value):
+        self._secret_key = value
+
+    secret_key = property(get_secret_key, set_secret_key)
+
+    def get_security_token(self):
+        return self._credentials.get_frozen_credentials().token
+
+    def set_security_token(self, value):
+        self._security_token = value
+
+    security_token = property(get_security_token, set_security_token)
+

--- a/tests/integration/sts/test_session_token.py
+++ b/tests/integration/sts/test_session_token.py
@@ -28,7 +28,8 @@ import unittest
 import os
 from boto.exception import BotoServerError
 from boto.sts.connection import STSConnection
-from boto.sts.credentials import Credentials
+from boto.anon_connection import AnonSTSConnection
+from boto.credentials import Credentials
 from boto.s3.connection import S3Connection
 
 
@@ -66,7 +67,7 @@ class SessionTokenTest(unittest.TestCase):
         print('--- tests completed ---')
 
     def test_assume_role_with_web_identity(self):
-        c = STSConnection(anon=True)
+        c = AnonSTSConnection()
         arn = 'arn:aws:iam::000240903217:role/FederatedWebIdentityRole'
         wit = 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
 

--- a/tests/unit/ecs/test_connection.py
+++ b/tests/unit/ecs/test_connection.py
@@ -55,6 +55,7 @@ class TestECSConnection(AWSMockServiceTestCase):
             ResponseGroup='Reviews'
         )
 
+        print self.actual_request.params.copy()
         self.assert_request_parameters(
             {'ItemId': '0316067938',
              'Operation': 'ItemLookup',
@@ -62,7 +63,7 @@ class TestECSConnection(AWSMockServiceTestCase):
              'Service': 'AWSECommerceService'},
             ignore_params_values=['Version', 'AWSAccessKeyId',
                                   'SignatureMethod', 'SignatureVersion',
-                                  'Timestamp'])
+                                  'Timestamp', 'SecurityToken'])
 
         items = list(item_set)
         self.assertEqual(len(items), 1)

--- a/tests/unit/sqs/test_connection.py
+++ b/tests/unit/sqs/test_connection.py
@@ -30,7 +30,7 @@ from boto.sqs.connection import SQSConnection
 from boto.sqs.regioninfo import SQSRegionInfo
 from boto.sqs.message import RawMessage
 from boto.sqs.queue import Queue
-from boto.connection import AWSQueryConnection
+from boto.aws_connection import AWSQueryConnection
 
 from nose.plugins.attrib import attr
 

--- a/tests/unit/sts/test_credentials.py
+++ b/tests/unit/sts/test_credentials.py
@@ -1,14 +1,17 @@
 import unittest
+import mock
 
-from boto.sts.credentials import Credentials
-
+import boto.credentials as credentials
+from datetime import datetime, timedelta
+from dateutil.tz import tzlocal
+from boto.exception import CredentialRetrievalError,InvalidConfigError
 
 class STSCredentialsTest(unittest.TestCase):
     sts = True
 
     def setUp(self):
         super(STSCredentialsTest, self).setUp()
-        self.creds = Credentials()
+        self.creds = credentials.Credentials()
 
     def test_to_dict(self):
         # This would fail miserably if ``Credentials.request_id`` hadn't been
@@ -23,7 +26,7 @@ class STSCredentialsTest(unittest.TestCase):
         })
 
         # Override.
-        creds = Credentials()
+        creds = credentials.Credentials()
         creds.access_key = 'something'
         creds.secret_key = 'crypto'
         creds.session_token = 'this'
@@ -36,3 +39,444 @@ class STSCredentialsTest(unittest.TestCase):
             'secret_key': 'crypto',
             'session_token': 'this'
         })
+
+class BaseEnvVar(unittest.TestCase):
+    def setUp(self):
+        # Automatically patches out os.environ for you
+        # and gives you a self.environ attribute that simulates
+        # the environment.  Also will automatically restore state
+        # for you in tearDown()
+        self.environ = {}
+        self.environ_patch = mock.patch('os.environ', self.environ)
+        self.environ_patch.start()
+
+    def tearDown(self):
+        self.environ_patch.stop()
+
+class TestCredentials(BaseEnvVar):
+    def _ensure_credential_is_normalized_as_unicode(self, access, secret):
+        c = credentials.Credentials(access_key=access, secret_key=secret)
+        self.assertTrue(isinstance(c.access_key, type(u'u')))
+        self.assertTrue(isinstance(c.secret_key, type(u'u')))
+
+    def test_detect_nonascii_character(self):
+        self._ensure_credential_is_normalized_as_unicode(
+            'foo\xe2\x80\x99', 'bar\xe2\x80\x99')
+
+    def test_unicode_input(self):
+        self._ensure_credential_is_normalized_as_unicode(
+            u'foo', u'bar')
+
+
+class TestRefreshableCredentials(TestCredentials):
+    def setUp(self):
+        super(TestRefreshableCredentials, self).setUp()
+        self.refresher = mock.Mock()
+        self.future_time = datetime.now(tzlocal()) + timedelta(hours=24)
+        self.expiry_time = \
+            datetime.now(tzlocal()) - timedelta(minutes=30)
+        self.metadata = {
+            'access_key': 'NEW-ACCESS',
+            'secret_key': 'NEW-SECRET',
+            'token': 'NEW-TOKEN',
+            'expiry_time': self.future_time.isoformat(),
+            'role_name': 'rolename',
+        }
+        self.refresher.return_value = self.metadata
+        self.mock_time = mock.Mock()
+        self.creds = credentials.RefreshableCredentials(
+            'ORIGINAL-ACCESS', 'ORIGINAL-SECRET', 'ORIGINAL-TOKEN',
+            self.expiry_time, self.refresher, 'iam-role',
+            time_fetcher=self.mock_time
+        )
+
+    def test_refresh_needed(self):
+        # The expiry time was set for 30 minutes ago, so if we
+        # say the current time is utcnow(), then we should need
+        # a refresh.
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        # We should refresh creds, if we try to access "access_key"
+        # or any of the cred vars.
+        self.assertEqual(self.creds.access_key, 'NEW-ACCESS')
+        self.assertEqual(self.creds.secret_key, 'NEW-SECRET')
+        self.assertEqual(self.creds.token, 'NEW-TOKEN')
+
+    def test_no_expiration(self):
+        creds = credentials.RefreshableCredentials(
+            'ORIGINAL-ACCESS', 'ORIGINAL-SECRET', 'ORIGINAL-TOKEN',
+            None, self.refresher, 'iam-role', time_fetcher=self.mock_time
+        )
+        self.assertFalse(creds.refresh_needed())
+
+    def test_no_refresh_needed(self):
+        # The expiry time was 30 minutes ago, let's say it's an hour
+        # ago currently.  That would mean we don't need a refresh.
+        self.mock_time.return_value = (
+            datetime.now(tzlocal()) - timedelta(minutes=60))
+        self.assertTrue(not self.creds.refresh_needed())
+
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(self.creds.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(self.creds.token, 'ORIGINAL-TOKEN')
+
+    def test_get_credentials_set(self):
+        # We need to return a consistent set of credentials to use during the
+        # signing process.
+        self.mock_time.return_value = (
+            datetime.now(tzlocal()) - timedelta(minutes=60))
+        self.assertTrue(not self.creds.refresh_needed())
+        credential_set = self.creds.get_frozen_credentials()
+        self.assertEqual(credential_set.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(credential_set.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(credential_set.token, 'ORIGINAL-TOKEN')
+
+    def test_refresh_returns_empty_dict(self):
+        self.refresher.return_value = {}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+
+        with self.assertRaises(CredentialRetrievalError):
+            self.creds.access_key
+
+    def test_refresh_returns_none(self):
+        self.refresher.return_value = None
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+
+        with self.assertRaises(CredentialRetrievalError):
+            self.creds.access_key
+
+    def test_refresh_returns_partial_credentials(self):
+        self.refresher.return_value = {'access_key': 'akid'}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+
+        with self.assertRaises(CredentialRetrievalError):
+            self.creds.access_key
+
+
+class TestDeferredRefreshableCredentials(unittest.TestCase):
+    def setUp(self):
+        self.refresher = mock.Mock()
+        self.future_time = datetime.now(tzlocal()) + timedelta(hours=24)
+        self.metadata = {
+            'access_key': 'NEW-ACCESS',
+            'secret_key': 'NEW-SECRET',
+            'token': 'NEW-TOKEN',
+            'expiry_time': self.future_time.isoformat(),
+            'role_name': 'rolename',
+        }
+        self.refresher.return_value = self.metadata
+        self.mock_time = mock.Mock()
+        self.mock_time.return_value = datetime.now(tzlocal())
+
+    def test_refresh_using_called_on_first_access(self):
+        creds = credentials.DeferredRefreshableCredentials(
+            self.refresher, 'iam-role', self.mock_time
+        )
+
+        # The credentials haven't been accessed, so there should be no calls.
+        self.refresher.assert_not_called()
+
+        # Now that the object has been accessed, it should have called the
+        # refresher
+        creds.get_frozen_credentials()
+        self.assertEqual(self.refresher.call_count, 1)
+
+    def test_refresh_only_called_once(self):
+        creds = credentials.DeferredRefreshableCredentials(
+            self.refresher, 'iam-role', self.mock_time
+        )
+
+        for _ in range(5):
+            creds.get_frozen_credentials()
+
+        # The credentials were accessed several times in a row, but only
+        # should call refresh once.
+        self.assertEqual(self.refresher.call_count, 1)
+
+
+class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
+    def setUp(self):
+        super(TestAssumeRoleWithWebIdentityCredentialFetcher, self).setUp()
+        self.role_arn = 'myrole'
+
+    def load_token(self):
+        return 'totally.a.token'
+
+    def some_future_time(self):
+        timeobj = datetime.now(tzlocal())
+        return timeobj + timedelta(hours=24)
+
+    def create_client_creator(self, with_response):
+        # Create a mock sts client that returns a specific response
+        # for assume_role.
+        connection = mock.Mock()
+        if isinstance(with_response, list):
+            connection.assume_role_with_web_identity.side_effect = with_response
+        else:
+            connection.assume_role_with_web_identity.return_value = with_response
+        return mock.Mock(return_value=connection)
+
+    def get_expected_creds_from_response(self, response):
+        expiration = response['Credentials']['expiration']
+        if isinstance(expiration, datetime):
+            expiration = expiration.isoformat()
+        return {
+            'access_key': response['Credentials']['access_key'],
+            'secret_key': response['Credentials']['secret_key'],
+            'token': response['Credentials']['session_token'],
+            'expiry_time': expiration
+        }
+
+    def test_no_cache(self):
+        response = {
+            'Credentials': {
+                'access_key': 'foo',
+                'secret_key': 'bar',
+                'session_token': 'baz',
+                'expiration': self.some_future_time().isoformat()
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        refresher = credentials.AssumeRoleWithWebIdentityCredentialFetcher(
+            client_creator, self.load_token, self.role_arn
+        )
+        expected_response = self.get_expected_creds_from_response(response)
+        response = refresher.fetch_credentials()
+
+        self.assertEqual(response, expected_response)
+
+    def test_retrieves_from_cache(self):
+        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        utc_timestamp = date_in_future.isoformat() + 'Z'
+        cache_key = (
+            '793d6e2f27667ab2da104824407e486bfec24a47'
+        )
+        cache = {
+            cache_key: {
+                'Credentials': {
+                    'access_key': 'foo-cached',
+                    'secret_key': 'bar-cached',
+                    'session_token': 'baz-cached',
+                    'expiration': utc_timestamp,
+                }
+            }
+        }
+        client_creator = mock.Mock()
+        refresher = credentials.AssumeRoleWithWebIdentityCredentialFetcher(
+            client_creator, self.load_token, self.role_arn, cache=cache
+        )
+        expected_response = self.get_expected_creds_from_response(
+            cache[cache_key]
+        )
+        response = refresher.fetch_credentials()
+
+        self.assertEqual(response, expected_response)
+        client_creator.assert_not_called()
+
+    def test_assume_role_in_cache_but_expired(self):
+        response = {
+            'Credentials': {
+                'access_key': 'foo',
+                'secret_key': 'bar',
+                'session_token': 'baz',
+                'expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        cache = {
+            'development--myrole': {
+                'Credentials': {
+                    'access_key': 'foo-cached',
+                    'secret_key': 'bar-cached',
+                    'session_token': 'baz-cached',
+                    'expiration': datetime.now(tzlocal()),
+                }
+            }
+        }
+
+        refresher = credentials.AssumeRoleWithWebIdentityCredentialFetcher(
+            client_creator, self.load_token, self.role_arn, cache=cache
+        )
+        expected = self.get_expected_creds_from_response(response)
+        response = refresher.fetch_credentials()
+
+        self.assertEqual(response, expected)
+
+class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
+    def setUp(self):
+        self.profile_name = 'some-profile'
+        self.config = {
+            'role_arn': 'arn:aws:iam::123:role/role-name',
+            'web_identity_token_file': '/some/path/token.jwt'
+        }
+
+    def create_client_creator(self, with_response):
+        # Create a mock sts client that returns a specific response
+        # for assume_role.
+        client = mock.Mock()
+        if isinstance(with_response, list):
+            client.assume_role_with_web_identity.side_effect = with_response
+        else:
+            client.assume_role_with_web_identity.return_value = with_response
+        return mock.Mock(return_value=client)
+
+    def some_future_time(self):
+        timeobj = datetime.now(tzlocal())
+        return timeobj + timedelta(hours=24)
+
+    def _mock_loader_cls(self, token=''):
+        mock_loader = mock.Mock(spec=credentials.FileWebIdentityTokenLoader)
+        mock_loader.return_value = token
+        mock_cls = mock.Mock()
+        mock_cls.return_value = mock_loader
+        return mock_cls
+
+    def _load_config(self):
+        return {
+            'profiles': {
+                self.profile_name: self.config,
+            }
+        }
+
+    def test_assume_role_with_no_cache(self):
+        response = {
+            'Credentials': {
+                'access_key': 'foo',
+                'secret_key': 'bar',
+                'session_token': 'baz',
+                'expiration': self.some_future_time().isoformat()
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        mock_loader_cls = self._mock_loader_cls('totally.a.token')
+        provider = credentials.AssumeRoleWithWebIdentityProvider(
+            load_config=self._load_config,
+            connection=client_creator,
+            cache={},
+            profile_name=self.profile_name,
+            token_loader_cls=mock_loader_cls,
+        )
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        mock_loader_cls.assert_called_with('/some/path/token.jwt')
+
+    def test_assume_role_retrieves_from_cache(self):
+        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        utc_timestamp = date_in_future.isoformat() + 'Z'
+
+        cache_key = (
+            'c29461feeacfbed43017d20612606ff76abc073d'
+        )
+        cache = {
+            cache_key: {
+                'Credentials': {
+                    'access_key': 'foo-cached',
+                    'secret_key': 'bar-cached',
+                    'session_token': 'baz-cached',
+                    'expiration': utc_timestamp,
+                }
+            }
+        }
+        mock_loader_cls = self._mock_loader_cls('totally.a.token')
+        client_creator = mock.Mock()
+        provider = credentials.AssumeRoleWithWebIdentityProvider(
+            connection=client_creator,
+            load_config=self._load_config,
+            cache=cache,
+            profile_name=self.profile_name,
+            token_loader_cls=mock_loader_cls,
+        )
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo-cached')
+        self.assertEqual(creds.secret_key, 'bar-cached')
+        self.assertEqual(creds.token, 'baz-cached')
+        client_creator.assert_not_called()
+
+    def test_assume_role_in_cache_but_expired(self):
+        expired_creds = datetime.now(tzlocal())
+        valid_creds = expired_creds + timedelta(hours=1)
+        response = {
+            'Credentials': {
+                'access_key': 'foo',
+                'secret_key': 'bar',
+                'session_token': 'baz',
+                'expiration': valid_creds,
+            },
+        }
+        cache = {
+            'development--myrole': {
+                'Credentials': {
+                    'access_key': 'foo-cached',
+                    'secret_key': 'bar-cached',
+                    'session_token': 'baz-cached',
+                    'expiration': expired_creds,
+                }
+            }
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        mock_loader_cls = self._mock_loader_cls('totally.a.token')
+        provider = credentials.AssumeRoleWithWebIdentityProvider(
+            load_config=self._load_config,
+            connection=client_creator,
+            cache=cache,
+            profile_name=self.profile_name,
+            token_loader_cls=mock_loader_cls,
+        )
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        mock_loader_cls.assert_called_with('/some/path/token.jwt')
+
+    def test_role_session_name_provided(self):
+        self.config['role_session_name'] = 'myname'
+        response = {
+            'Credentials': {
+                'access_key': 'foo',
+                'secret_key': 'bar',
+                'session_token': 'baz',
+                'expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        mock_loader_cls = self._mock_loader_cls('totally.a.token')
+        provider = credentials.AssumeRoleWithWebIdentityProvider(
+            load_config=self._load_config,
+            connection=client_creator,
+            cache={},
+            profile_name=self.profile_name,
+            token_loader_cls=mock_loader_cls,
+        )
+        # The credentials won't actually be assumed until they're requested.
+        provider.load().get_frozen_credentials()
+
+        client = client_creator.return_value
+        client.assume_role_with_web_identity.assert_called_with(
+            role_arn='arn:aws:iam::123:role/role-name',
+            role_session_name='myname',
+            web_identity_token='totally.a.token'
+        )
+
+    def test_role_arn_not_set(self):
+        del self.config['role_arn']
+        client_creator = self.create_client_creator(with_response={})
+        provider = credentials.AssumeRoleWithWebIdentityProvider(
+            load_config=self._load_config,
+            connection=client_creator,
+            cache={},
+            profile_name=self.profile_name,
+        )
+        # If the role arn isn't set but the token path is raise an error
+        with self.assertRaises(InvalidConfigError):
+            provider.load()

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -27,7 +27,8 @@ from httpretty import HTTPretty
 
 from boto import UserAgent
 from boto.compat import json, parse_qs
-from boto.connection import AWSQueryConnection, AWSAuthConnection, HTTPRequest
+from boto.aws_connection import AWSQueryConnection, AWSAuthConnection
+from boto.connection import HTTPRequest
 from boto.exception import BotoServerError
 from boto.regioninfo import RegionInfo
 


### PR DESCRIPTION
This commit backports the boto3 assume_role_with_web_identity_ funtion to our boto repository. Upon creation of a connection (such as S3, ec2 etc..) the sdk will check for the environment variable AWS_WEB_IDENTITY_TOKEN_FILE and if it exists, it will automatically assume a role using the JWT token in the file and obtain credentials before proceeding to the origin connection. The credentials assumed will also automatically be refreshed

This is a post about fine-grained roles for k8s: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
Each k8s pod is able to obtain a jwt token which it can use to assume role and obtain temporary credentials using the boto SDK when establishing an aws connection. However, this feature is only available in boto3, and we use a version of boto2. Therefore, although our pods have a jwt token, our sdk does not do anything with it. 
This commit backports this function so that every app in clroot using boto to access aws will automatically assume a role and obtain credentials needed 